### PR TITLE
Add missing privileges and notes for the least-privilege deployment model

### DIFF
--- a/Pipelines/README.md
+++ b/Pipelines/README.md
@@ -78,13 +78,15 @@ If your organisation requires tighter RBAC, you can replace **Contributor** with
 
 | Role | Scope | Purpose |
 |------|-------|---------|
+| **Reader** | Subscription | Allow the discovery of the target resource group |
 | **Resource Group Contributor** | Resource Group | Create and manage resources within the resource group |
 | **Microsoft Sentinel Contributor** | Resource Group | Sentinel settings (Anomalies, EyesOn, analytics rules, content deployment) |
 | **Log Analytics Contributor** | Resource Group | Log Analytics workspace management and summary rule deployment *(Stage 4)* |
 | **Security Administrator** (Entra ID) | Tenant | UEBA and Entity Analytics settings *(optional)* |
 | **CustomDetection.ReadWrite.All** (Graph) | Tenant | Defender XDR custom detection rules *(Stage 5)* |
 
-> **Note**: With the least-privilege approach, the resource group must be pre-created (or use a separate identity with subscription-level Contributor for the initial Bicep deployment). For greenfield deployments that create the resource group, subscription-level **Contributor** is the simplest option.
+> **Note**: With the least-privilege approach, the resource group must be pre-created (or use a separate identity with subscription-level Contributor for the initial Bicep deployment) and `Microsoft.OperationsManagement` and `Microsoft.SecurityInsights` resource providers must be manually registered in the subscription.
+For greenfield deployments that create the resource group, subscription-level **Contributor** is the simplest option.
 
 - Variable group `sentinel-deployment` linked to the pipeline
 


### PR DESCRIPTION
### Problem
When using the least-privileged deployment model, it is needed to assign Reader role to the Service Principal, otherwise the `Get-AzResourceGroup` in the "Check for Existing Resources" step fails, since the API call is performed at the subscription level.

Also, in a greenfield environment, it is necessary to manually register the Resource Providers `Microsoft.OperationsManagement` and `Microsoft.SecurityInsights`, the same way it is done by the "Register Required Resource Providers" step.

### Fix
Added Reader role in the permission table and a note about the needed Resource Providers

### Further enhancements 
I would personally prefer to highlight the least-privileged deployment model as preferred method, only fallbacking to the one that uses the Contributor role only for troubleshooting purposes.