### PR TITLE
chore(pipelines): expand default Content Hub solutions to operational set

### DIFF
--- a/Pipelines/Sentinel-Deploy.yml
+++ b/Pipelines/Sentinel-Deploy.yml
@@ -67,7 +67,7 @@ parameters:
   - name: solutions
     displayName: "  Content Hub › Solutions (comma-separated)"
     type: string
-    default: "Microsoft Defender XDR,Azure Activity,Microsoft Entra ID,Microsoft Defender for Cloud,Microsoft 365,Microsoft Defender for Endpoint,Windows Security Events,Threat Intelligence (New),UEBA Essentials"
+    default: "Analytics Health & Audit,Azure Activity,Azure DevOps Auditing,Azure Key Vault,Azure Logic Apps,Azure Network Security Groups,Azure Resource Graph,Azure Storage,Common Event Format,Data Collection Rule Toolkit,Microsoft 365,Microsoft Defender for Cloud,Microsoft Defender for Cloud Apps,Microsoft Defender for Endpoint,Microsoft Defender for Identity,Microsoft Defender Threat Intelligence,Microsoft Defender XDR,Microsoft Entra ID,Microsoft Sentinel Optimization Workbook,SOC Handbook,Summary Rules Workbook,Syslog,Threat Intelligence (NEW),Windows Security Events,Windows Server DNS,Workspace Usage Report"
 
   - name: severitiesToInclude
     displayName: "  Content Hub › Analytics Rule Severities"


### PR DESCRIPTION
## Summary

- Bring the GitHub pipeline definition into line with the production default that the ADO mirror has been running since 2026-05-07.
- Default `solutions` parameter on `Pipelines/Sentinel-Deploy.yml` expanded from 9 entries to 26, alphabetised, with `UEBA Essentials` dropped from the default and `Threat Intelligence (New)` case-corrected to `Threat Intelligence (NEW)` to match the current Content Hub catalogue entry.
- Operators who set the parameter explicitly at queue time are unaffected; this only changes the default value when the parameter is left untouched.

This is cherry-picked from commit `258fcb9` on the ADO mirror, with the original author (Toby Goulden) preserved. The diverged-on-ADO state is now reconciled.

## Test plan

- [ ] Manual: open the deploy pipeline parameter UI on Azure DevOps and on GitHub Actions and confirm both show the same default list.
- [ ] Run the deploy pipeline against the test workspace with default parameters and confirm Content Hub installs every solution without API errors.
- [ ] PR-validation gate green.