### PR TITLE
chore(workflows): align GH deploy solutions default with ADO

### DIFF
--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -63,7 +63,7 @@ on:
       solutions:
         description: "Content Hub: Solutions (comma-separated)"
         type: string
-        default: "Microsoft Defender XDR,Azure Activity,Microsoft Entra ID,Microsoft Defender for Cloud,Microsoft 365,Microsoft Defender for Endpoint,Windows Security Events,Threat Intelligence (New),UEBA Essentials"
+        default: "Analytics Health & Audit,Azure Activity,Azure DevOps Auditing,Azure Key Vault,Azure Logic Apps,Azure Network Security Groups,Azure Resource Graph,Azure Storage,Common Event Format,Data Collection Rule Toolkit,Microsoft 365,Microsoft Defender for Cloud,Microsoft Defender for Cloud Apps,Microsoft Defender for Endpoint,Microsoft Defender for Identity,Microsoft Defender Threat Intelligence,Microsoft Defender XDR,Microsoft Entra ID,Microsoft Sentinel Optimization Workbook,SOC Handbook,Summary Rules Workbook,Syslog,Threat Intelligence (NEW),Windows Security Events,Windows Server DNS,Workspace Usage Report"
       severities_to_include:
         description: "Content Hub: Analytics Rule Severities"
         type: string
@@ -354,7 +354,7 @@ jobs:
         with:
           azPSVersion: "latest"
           inlineScript: |
-            $solutionList = "${{ inputs.solutions || 'Microsoft Defender XDR,Azure Activity' }}" -split ',' | ForEach-Object { $_.Trim() }
+            $solutionList = "${{ inputs.solutions || 'Analytics Health & Audit,Azure Activity,Azure DevOps Auditing,Azure Key Vault,Azure Logic Apps,Azure Network Security Groups,Azure Resource Graph,Azure Storage,Common Event Format,Data Collection Rule Toolkit,Microsoft 365,Microsoft Defender for Cloud,Microsoft Defender for Cloud Apps,Microsoft Defender for Endpoint,Microsoft Defender for Identity,Microsoft Defender Threat Intelligence,Microsoft Defender XDR,Microsoft Entra ID,Microsoft Sentinel Optimization Workbook,SOC Handbook,Summary Rules Workbook,Syslog,Threat Intelligence (NEW),Windows Security Events,Windows Server DNS,Workspace Usage Report' }}" -split ',' | ForEach-Object { $_.Trim() }
             $severityList = "${{ inputs.severities_to_include || 'High,Medium,Low,Informational' }}" -split ',' | ForEach-Object { $_.Trim() }
 
             $scriptParams = @{


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/sentinel-deploy.yml` so the GH deploy workflow's default Content Hub solutions list matches the operational set already shipped to `Pipelines/Sentinel-Deploy.yml` in #9.
- Fixes both the `workflow_dispatch` UI default (L66) and the cron-trigger fallback string (L357) — without the L357 change the weekly Monday 04:00 UTC cron silently falls back to just `Microsoft Defender XDR, Azure Activity`, diverging from what ADO deploys from the same repo.
- Nightly E2E workflow left untouched — it intentionally deploys only `Azure Activity` to stay under the smoke-test wall-clock budget.

## Test plan

- [ ] PR validation gate passes (Pester, Bicep build, ARM What-If, KQL syntax, dependency-manifest drift)
- [ ] After merge, trigger `Deploy Sentinel` via `workflow_dispatch` and confirm the **Solutions** input shows the 26-solution operational set as its default value
- [ ] Confirm scheduled run (or dry-run trigger with empty `solutions`) resolves the same 26-solution list via the cron-fallback path