### PR TITLE
fix(workflows): collapse custom skip toggles to fit GH 25-input cap

### DIFF
--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -102,42 +102,17 @@ on:
         default: false
 
       # ── Custom Content (Stage 4) ─────────────────────────────────────
-      skip_custom_parsers:
-        description: "Custom: Skip KQL Parsers/Functions"
-        type: boolean
-        default: false
-      skip_custom_detections:
-        description: "Custom: Skip Analytical Rules (YAML)"
-        type: boolean
-        default: false
-      skip_community_detections:
-        description: "Custom: Skip Community Detections (Dalonso)"
-        type: boolean
-        default: true
-      skip_custom_watchlists:
-        description: "Custom: Skip Watchlists (JSON+CSV)"
-        type: boolean
-        default: false
-      skip_custom_playbooks:
-        description: "Custom: Skip Playbooks (ARM)"
-        type: boolean
-        default: false
-      skip_custom_workbooks:
-        description: "Custom: Skip Workbooks (Gallery JSON)"
-        type: boolean
-        default: false
-      skip_custom_hunting_queries:
-        description: "Custom: Skip Hunting Queries (YAML)"
-        type: boolean
-        default: false
-      skip_custom_automation_rules:
-        description: "Custom: Skip Automation Rules (JSON)"
-        type: boolean
-        default: false
-      skip_custom_summary_rules:
-        description: "Custom: Skip Summary Rules (JSON)"
-        type: boolean
-        default: false
+      # GitHub caps workflow_dispatch at 25 inputs. The ADO equivalent in
+      # Pipelines/Sentinel-Deploy.yml exposes nine separate skipCustom*
+      # boolean parameters here; we collapse them into one comma-separated
+      # string so the GH workflow stays under the cap while preserving
+      # identical downstream behaviour (Deploy-CustomContent.ps1 still
+      # receives the individual -Skip* script parameters via the parsing
+      # block in the deploy-custom-content job below).
+      skip_custom_content_types:
+        description: "Custom: Skip Content Types (comma-separated subset of: parsers, detections, community-detections, watchlists, playbooks, workbooks, hunting-queries, automation-rules, summary-rules)"
+        type: string
+        default: "community-detections"
 
       # ── General ──────────────────────────────────────────────────────
       smart_deployment:
@@ -451,15 +426,27 @@ jobs:
             $playbookRG = "${{ vars.PLAYBOOK_RESOURCE_GROUP }}"
             if ($playbookRG) { $scriptParams['PlaybookResourceGroup'] = $playbookRG }
 
-            if ("${{ inputs.skip_custom_parsers }}" -eq "true")          { $scriptParams['SkipParsers']               = $true }
-            if ("${{ inputs.skip_custom_detections }}" -eq "true")       { $scriptParams['SkipDetections']            = $true }
-            if ("${{ inputs.skip_community_detections }}" -ne "false")   { $scriptParams['SkipCommunityDetections']  = $true }
-            if ("${{ inputs.skip_custom_watchlists }}" -eq "true")       { $scriptParams['SkipWatchlists']            = $true }
-            if ("${{ inputs.skip_custom_playbooks }}" -eq "true")        { $scriptParams['SkipPlaybooks']      = $true }
-            if ("${{ inputs.skip_custom_workbooks }}" -eq "true")        { $scriptParams['SkipWorkbooks']      = $true }
-            if ("${{ inputs.skip_custom_hunting_queries }}" -eq "true")  { $scriptParams['SkipHuntingQueries'] = $true }
-            if ("${{ inputs.skip_custom_automation_rules }}" -eq "true") { $scriptParams['SkipAutomationRules']= $true }
-            if ("${{ inputs.skip_custom_summary_rules }}" -eq "true")   { $scriptParams['SkipSummaryRules']   = $true }
+            # Parse the consolidated skip_custom_content_types string
+            # into individual -Skip* script parameters. The cron trigger
+            # has no inputs.*, so the `|| 'community-detections'` fallback
+            # matches the workflow_dispatch default for parity. ADO's
+            # equivalent block (Pipelines/Sentinel-Deploy.yml) sets the
+            # same -Skip* parameters from its nine individual boolean
+            # parameters — net effect on Deploy-CustomContent.ps1 is
+            # identical across both platforms.
+            $skipList = "${{ inputs.skip_custom_content_types || 'community-detections' }}" -split ',' |
+                ForEach-Object { $_.Trim().ToLower() } |
+                Where-Object { $_ }
+
+            if ($skipList -contains 'parsers')              { $scriptParams['SkipParsers']              = $true }
+            if ($skipList -contains 'detections')           { $scriptParams['SkipDetections']           = $true }
+            if ($skipList -contains 'community-detections') { $scriptParams['SkipCommunityDetections'] = $true }
+            if ($skipList -contains 'watchlists')           { $scriptParams['SkipWatchlists']           = $true }
+            if ($skipList -contains 'playbooks')            { $scriptParams['SkipPlaybooks']            = $true }
+            if ($skipList -contains 'workbooks')            { $scriptParams['SkipWorkbooks']            = $true }
+            if ($skipList -contains 'hunting-queries')      { $scriptParams['SkipHuntingQueries']       = $true }
+            if ($skipList -contains 'automation-rules')     { $scriptParams['SkipAutomationRules']      = $true }
+            if ($skipList -contains 'summary-rules')        { $scriptParams['SkipSummaryRules']         = $true }
             if ("${{ inputs.smart_deployment }}" -ne "false")            { $scriptParams['SmartDeployment']    = $true }
             if ("${{ inputs.what_if }}" -eq "true")                      { $scriptParams['WhatIf']             = $true }
 


### PR DESCRIPTION
## Summary

- Fixes `Invalid workflow file: you may only define up to 25 inputs for a workflow_dispatch event` on [`.github/workflows/sentinel-deploy.yml`](.github/workflows/sentinel-deploy.yml). Until this lands, every scheduled or manual run of **Deploy Sentinel** aborts at YAML parse time before any job starts, and the Actions UI shows the workflow as `.github/workflows/sentinel-deploy.yml` instead of its friendly `Deploy Sentinel` name.
- Collapses the nine `skip_custom_*` boolean inputs into one comma-separated `skip_custom_content_types` string input. The `deploy-custom-content` job parses the string back into the same nine individual `-Skip*` parameters that `Deploy-CustomContent.ps1` already accepts — downstream behaviour is byte-identical, only the trigger surface changes.
- `Pipelines/Sentinel-Deploy.yml` (ADO) is deliberately untouched. ADO has no input cap and is currently shipping production runs; rewriting it to match the GH surface would add risk for zero functional benefit. The two pipelines now diverge at the parameter layer but converge at the script-parameter layer.

## New input contract

```text
skip_custom_content_types (string, default "community-detections")
  Comma-separated, case-insensitive, any subset of:
    parsers, detections, community-detections, watchlists,
    playbooks, workbooks, hunting-queries, automation-rules,
    summary-rules
```

Examples:

| User intent | Input value |
|---|---|
| Default (skip only community detections, same as today) | `community-detections` (default) |
| Deploy everything including community detections | `` (empty string) |
| Skip playbooks and workbooks only | `playbooks,workbooks` |
| Skip everything custom | `parsers,detections,community-detections,watchlists,playbooks,workbooks,hunting-queries,automation-rules,summary-rules` |

## Input count

| | Before | After |
|---|---:|---:|
| Total `workflow_dispatch` inputs | 28 ❌ | 20 ✅ |
| Headroom under GH 25-input cap | -3 | +5 |

Verified by parsing the file via `powershell-yaml` 0.4.12 and counting `.on.workflow_dispatch.inputs.Keys`.

## Test plan

- [ ] PR-validation gate passes (Pester, Bicep build, ARM What-If, KQL syntax, dependency-manifest drift)
- [ ] After merge, the workflow appears as **Deploy Sentinel** in the Actions UI sidebar (not as a file path)
- [ ] Trigger `Deploy Sentinel` via `workflow_dispatch` with the default `skip_custom_content_types=community-detections` and confirm `Deploy-CustomContent.ps1` is invoked with `-SkipCommunityDetections` set and no other `-Skip*` flags
- [ ] Trigger a second run with `skip_custom_content_types=playbooks,workbooks` and confirm `-SkipPlaybooks` + `-SkipWorkbooks` + `-SkipCommunityDetections=$false` are passed