### PR TITLE
fix(workflows): checkout repo before invoking local composite actions

### DIFF
--- a/.github/workflows/sentinel-deploy-nightly.yml
+++ b/.github/workflows/sentinel-deploy-nightly.yml
@@ -90,6 +90,13 @@ jobs:
     outputs:
       resources_exist: ${{ steps.check.outputs.resources_exist }}
     steps:
+      # Required even though this job reads no repo files: the
+      # Azure-login composite below lives under .github/actions/ in
+      # this repo, and local composite actions can only be resolved
+      # once the runner has the repo on disk.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Azure Login (OIDC)
         uses: ./.github/actions/azure-login-oidc
         with:

--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -152,6 +152,13 @@ jobs:
     outputs:
       resources_exist: ${{ steps.check.outputs.resources_exist }}
     steps:
+      # Required even though this job reads no repo files: the
+      # Azure-login composite below lives under .github/actions/ in
+      # this repo, and local composite actions can only be resolved
+      # once the runner has the repo on disk.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Azure Login (OIDC)
         uses: ./.github/actions/azure-login-oidc
         with:


### PR DESCRIPTION
## Summary

- Fixes `Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.github/actions/azure-login-oidc'` on stage 1 of both **Deploy Sentinel** workflows.
- Root cause: the `check-infrastructure` job in both files reads no repo content itself, so `actions/checkout@v4` was skipped — but the very first step calls the local composite action `./.github/actions/azure-login-oidc`, which the runner can only load *from disk*. Every Deploy Sentinel run since the migration from inline `Azure/login@v2` to the composite action has aborted at stage 1 before any stage 2-5 work could start.
- Two files touched (`sentinel-deploy.yml`, `sentinel-deploy-nightly.yml`), both gain the same single `- uses: actions/checkout@v4` step at the top of `check-infrastructure`. The matching stages 2-5 already do this correctly.

## Audit

Ran a repo-wide scan for jobs that `uses: ./.github/actions/*` without a prior `actions/checkout@v4` step:

| Workflow | Before this PR | After this PR |
|---|---|---|
| `sentinel-deploy.yml` | `check-infrastructure` missing | clean |
| `sentinel-deploy-nightly.yml` | `check-infrastructure` missing | clean |
| `sentinel-dcr-inventory.yml` | clean | clean |
| `sentinel-dependency-update.yml` | clean | clean |
| `sentinel-drift-detect.yml` | clean | clean |
| `pr-validation.yml` | clean | clean |

Both files also parsed cleanly via `powershell-yaml` 0.4.12 round-trip.

## Test plan

- After merge, trigger `Deploy Sentinel` via `workflow_dispatch` with **Dry Run** ticked and confirm `check-infrastructure` completes successfully
- Confirm nightly E2E run on next 03:00 UTC fire-time (or trigger manually) clears stage 1 without the composite-action error

## Out of scope

`Pipelines/Sentinel-Deploy.yml` (ADO) — local-composite-action resolution is GitHub-Actions-specific; ADO has a different template-reuse model and is unaffected by this bug.