### PR TITLE
fix(workflows): strip CR via tr — BusyBox xargs ignores CR as whitespace

### DIFF
--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -252,14 +252,28 @@ jobs:
         uses: Azure/cli@v2
         with:
           inlineScript: |
-            # Trim any leading/trailing whitespace from the optional
-            # PLAYBOOK_RESOURCE_GROUP repo variable. `xargs` with no
-            # arguments echoes its input with surrounding whitespace
-            # collapsed; an empty input stays empty, which the Bicep
-            # template treats as "no separate playbook RG required"
-            # (Bicep/main.bicep:55 only fires the playbookRg resource
-            # when playbookRgName is non-empty and != rgName).
-            PLAYBOOK_RG=$(echo "${{ vars.PLAYBOOK_RESOURCE_GROUP }}" | xargs)
+            # Strip ALL whitespace (space, tab, CR, LF, FF, VT) from
+            # the optional PLAYBOOK_RESOURCE_GROUP repo variable. Azure
+            # RG names cannot contain any whitespace, so destructive
+            # stripping is safe and matches the intent.
+            #
+            # `tr -d '[:space:]'` replaces the earlier `xargs` approach
+            # because the Azure CLI runner image
+            # (mcr.microsoft.com/azure-cli) is Alpine-based and ships
+            # BusyBox xargs, which — unlike GNU xargs — does NOT treat
+            # CR ('\r') as whitespace. A GH repo variable accidentally
+            # carrying CRLF line endings then leaked a trailing '\r'
+            # into the ARM call:
+            #   InvalidResourceGroup: 'rg-name\r' has these invalid
+            #   characters: '\r'.
+            # `tr -d '[:space:]'` is POSIX-portable and strips every
+            # whitespace class on every shell environment we target.
+            #
+            # Empty input stays empty, which Bicep/main.bicep:55 treats
+            # as "no separate playbook RG required" (the conditional
+            # playbookRg resource only fires when playbookRgName is
+            # non-empty and != rgName).
+            PLAYBOOK_RG=$(printf '%s' "${{ vars.PLAYBOOK_RESOURCE_GROUP }}" | tr -d '[:space:]')
 
             az deployment sub create \
               --location "${{ env.REGION }}" \


### PR DESCRIPTION
## Summary

Follow-up to #18. The `xargs` whitespace defence added in #18 works under GNU xargs but breaks on **BusyBox xargs**, which is what ships in the Alpine-based Azure CLI runner image (`mcr.microsoft.com/azure-cli`). BusyBox xargs treats space, tab and LF as whitespace but **does not** treat CR as whitespace.

A GitHub repo variable carrying CRLF endings therefore got partially stripped — LFs collapsed, trailing CR survived — and Azure rejected the ARM call:

```
ERROR: InvalidResourceGroup: 'prt-uks-pbs-rg\r' has these invalid
characters: '\r'.
```

## Root cause

| Path | Whitespace handler | CR result |
|---|---|---|
| Stage 1 probe (PowerShell `.Trim()`) | full POSIX whitespace incl. CR | ✅ stripped |
| Stage 4 deploy-custom-content (PowerShell `.Trim()`) | full POSIX whitespace incl. CR | ✅ stripped |
| **Stage 2 Bicep deploy (BusyBox `xargs`)** | space/tab/LF only — no CR | ❌ CR leaks through |

Confirmed by reproducing on Alpine via `printf 'x\r' \| xargs \| od -c` (CR survives).

## Fix

Replace `echo "$value" \| xargs` with `printf '%s' "$value" \| tr -d '[:space:]'`. `tr -d '[:space:]'` is POSIX-portable and strips every member of the whitespace class (space, tab, CR, LF, FF, VT). Azure RG names cannot contain any whitespace anyway, so destructive stripping is safe and matches the intent.

`printf '%s'` instead of `echo` avoids the long-standing shell-portability quirk where `echo` handling of trailing newlines and escape sequences varies across implementations.

## User action still recommended (not required)

The workflow is now robust regardless, but for hygiene re-set the GH repo variable with a clean value:

```powershell
gh variable set PLAYBOOK_RESOURCE_GROUP `
    --repo noodlemctwoodle/Sentinel-As-Code `
    --body "prt-uks-pbs-rg"
```

## Test plan

- [ ] PR-validation gate passes
- [ ] After merge, re-trigger the failed Deploy Sentinel run — Stage 2 should now invoke `az deployment sub create` with `playbookRgName="prt-uks-pbs-rg"` (no CR), Bicep should provision the playbook RG, and Stage 4 should deploy playbooks into it
- [ ] Local POSIX `tr -d '[:space:]'` on `'prt-uks-pbs-rg\r\n\r\n'` correctly produces `'prt-uks-pbs-rg'` (already verified)

## Out of scope

`Pipelines/Sentinel-Deploy.yml` (ADO) — uses `$(playbookResourceGroup)` via ADO pipeline variable normalisation, no equivalent CR leak path.