### PR TITLE
feat(workflows): deploy only what's missing — gate Sentinel module

### DIFF
--- a/.github/agents/pipeline-engineer.agent.md
+++ b/.github/agents/pipeline-engineer.agent.md
@@ -7,9 +7,11 @@ tools: ['search/codebase', 'search/usages', 'search/changes', 'edit/applyPatch',
 # Pipeline Engineer agent
 
 You own the CI/CD layer. You edit GitHub Actions workflows and
-Azure DevOps pipelines, keep them in lockstep (ADO is the source of
-truth), maintain the composite actions, manage cron schedules, and
-diagnose pipeline failures.
+Azure DevOps pipelines, keep them in lockstep (ADO is the default
+source of truth with documented carve-outs — see
+[`instructions/workflows.instructions.md`](../instructions/workflows.instructions.md)
+Hard rule 1), maintain the composite actions, manage cron schedules,
+and diagnose pipeline failures.
 
 ## What you handle
 
@@ -71,10 +73,12 @@ Composite actions:
 
 ### Adding a new step / job
 
-1. **Decide which platform owns the change.** ADO is the source of
-   truth. If the change is platform-specific (e.g. composite-action
-   adoption is GitHub-only), say so explicitly in the commit
-   message.
+1. **Decide which platform owns the change.** ADO is the default
+   source of truth. If the change is platform-specific (e.g.
+   composite-action adoption is GitHub-only) or otherwise qualifies
+   under the documented divergence carve-out
+   ([`instructions/workflows.instructions.md`](../instructions/workflows.instructions.md)
+   Hard rule 1), say so explicitly in the commit message.
 2. **Use the composite actions** — never inline `Azure/login@v2` or
    `Install-Module` patterns. The composites are
    `./.github/actions/azure-login-oidc` and
@@ -94,7 +98,11 @@ Composite actions:
      issues: write         # gh issue create
    ```
 5. **Mirror to the other platform** — port the same change to ADO
-   (or GitHub) in the same PR. Don't ship a parity divergence.
+   (or GitHub) in the same PR. Don't ship a parity divergence
+   unless it qualifies under the documented carve-out
+   ([`instructions/workflows.instructions.md`](../instructions/workflows.instructions.md)
+   Hard rule 1) — in that case, document the reason inline and
+   track the follow-up port if it's a one-direction-first fix.
 
 ### Cross-porting an ADO change to GitHub
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,8 +21,11 @@ automation rules, summary rules, and Defender XDR custom detections.
 Two equivalent CI/CD platforms are supported:
 
 - **GitHub Actions** — under `.github/workflows/`
-- **Azure DevOps Pipelines** — under `Pipelines/` (the source of truth
-  the GitHub workflows mirror)
+- **Azure DevOps Pipelines** — under `Pipelines/`. ADO is the default
+  source of truth that GitHub workflows mirror, with documented
+  platform-forced and one-direction-first divergences allowed. See
+  [`instructions/workflows.instructions.md`](instructions/workflows.instructions.md)
+  Hard rule 1 for the full carve-out policy.
 
 Start any unfamiliar task by reading [`Docs/README.md`](../Docs/README.md).
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -7,8 +7,10 @@ applyTo: ".github/workflows/**/*.yml,.github/actions/**/*.yml,Pipelines/**/*.yml
 # CI/CD workflows and pipelines
 
 GitHub Actions workflows live under `.github/workflows/`; Azure DevOps
-pipelines live under `Pipelines/`. The ADO version is the source of
-truth — GitHub workflows mirror ADO behaviour. Reference doc:
+pipelines live under `Pipelines/`. The ADO version is the default
+source of truth — GitHub workflows mirror ADO behaviour except in
+the narrow documented cases covered under Hard rule 1 below.
+Reference doc:
 [`Docs/Deployment/Pipelines.md`](../../Docs/Deployment/Pipelines.md).
 
 ## File inventory
@@ -37,9 +39,35 @@ instead of inlining `Azure/login@v2` or `Install-Module` patterns:
 
 ## Hard rules
 
-1. **ADO is the source of truth.** When the two diverge, change ADO
-   first, then port to GitHub. The reverse direction creates merge
-   conflicts that are hard to spot in review.
+1. **ADO is the default source of truth.** When the two diverge,
+   change ADO first, then port to GitHub. The reverse direction
+   creates merge conflicts that are hard to spot in review.
+
+   **Documented divergence is allowed** in the narrow cases below.
+   Where it exists, justify it inline (workflow comment, commit
+   message, or PR description) and reference the forcing constraint
+   so future readers don't mistake the divergence for drift:
+
+   - **Platform-forced divergence.** A constraint that exists on
+     one platform but not the other forces a different shape. The
+     canonical example is GitHub's 25-input `workflow_dispatch`
+     cap (ADO has no equivalent limit), which is why
+     `sentinel-deploy.yml` exposes a single
+     `skip_custom_content_types` comma-separated string where
+     `Pipelines/Sentinel-Deploy.yml` exposes nine separate boolean
+     parameters. BusyBox vs GNU shell utilities in container
+     images, GitHub-only `gh issue create` patterns in nightly
+     workflows, and similar one-sided platform behaviours qualify.
+
+   - **One-direction-first bug fixes.** When a bug affects both
+     platforms but the fix lands on one first (typically because
+     the maintainer hit the bug there first), this is acceptable
+     short-term but the divergence is not the end state. Track the
+     pending port as a follow-up issue or a TODO in the PR
+     description so it doesn't become permanent by neglect.
+
+   Drift caught in code review without a documented reason should
+   be reverted, not retroactively justified.
 2. **Pin versions for every PSGallery / NuGet / GitHub Action you
    add.** Workflow-level env vars (`PESTER_VERSION`, `YAML_VERSION`,
    `KUSTO_LANGUAGE_VERSION`) are the convention. A breaking change

--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -150,7 +150,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.deploy_infrastructure != false }}
     outputs:
-      resources_exist: ${{ steps.check.outputs.resources_exist }}
+      bicep_needed:    ${{ steps.check.outputs.bicep_needed }}
+      deploy_sentinel: ${{ steps.check.outputs.deploy_sentinel }}
     steps:
       # Required even though this job reads no repo files: the
       # Azure-login composite below lives under .github/actions/ in
@@ -172,52 +173,84 @@ jobs:
         with:
           azPSVersion: "latest"
           inlineScript: |
+            # Per-component probe. The output drives two decisions in
+            # Stage 2:
+            #
+            #   bicep_needed    — gate on whether to run Bicep at all
+            #                     (true if ANY component is missing).
+            #   deploy_sentinel — whether the Sentinel module should
+            #                     run inside Bicep (false if Sentinel
+            #                     is already onboarded). False allows
+            #                     main.bicep to provision only the
+            #                     missing optional playbook RG without
+            #                     re-creating the non-idempotent
+            #                     SecurityInsights/onboardingStates
+            #                     resource, which returns Conflict on
+            #                     re-deploy.
             Write-Host "Checking for existing Sentinel infrastructure..."
-            $resourcesExist = "true"
 
-            # Sentinel RG + workspace must both exist for the main
-            # infrastructure to be considered current.
+            $sentinelReady    = $true
+            $playbookRgReady  = $true
+
+            # ── Sentinel RG + workspace + onboarding state ──────────
             $rg = Get-AzResourceGroup -Name "${{ env.RESOURCE_GROUP }}" -ErrorAction SilentlyContinue
             if (-not $rg) {
-                Write-Host "Resource Group '${{ env.RESOURCE_GROUP }}' not found — Bicep deployment required."
-                $resourcesExist = "false"
+                Write-Host "  Sentinel RG '${{ env.RESOURCE_GROUP }}' missing."
+                $sentinelReady = $false
             } else {
+                Write-Host "  Sentinel RG '${{ env.RESOURCE_GROUP }}' exists."
+
                 $law = Get-AzOperationalInsightsWorkspace `
                     -ResourceGroupName "${{ env.RESOURCE_GROUP }}" `
                     -Name "${{ env.WORKSPACE_NAME }}" `
                     -ErrorAction SilentlyContinue
                 if (-not $law) {
-                    Write-Host "Workspace '${{ env.WORKSPACE_NAME }}' not found — Bicep deployment required."
-                    $resourcesExist = "false"
+                    Write-Host "  Workspace '${{ env.WORKSPACE_NAME }}' missing."
+                    $sentinelReady = $false
                 } else {
-                    Write-Host "Workspace '${{ env.WORKSPACE_NAME }}' exists."
+                    Write-Host "  Workspace '${{ env.WORKSPACE_NAME }}' exists."
+
+                    # Sentinel onboarding state is the non-idempotent
+                    # resource that causes Conflict on re-deploy.
+                    # Treat its existence as the canonical "Sentinel
+                    # is onboarded" signal.
+                    $subId = (Get-AzContext).Subscription.Id
+                    $onboardingId = "/subscriptions/$subId/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.OperationalInsights/workspaces/${{ env.WORKSPACE_NAME }}/providers/Microsoft.SecurityInsights/onboardingStates/default"
+                    $onboarding = Get-AzResource -ResourceId $onboardingId -ApiVersion "2024-09-01" -ErrorAction SilentlyContinue
+                    if (-not $onboarding) {
+                        Write-Host "  Sentinel onboarding state missing."
+                        $sentinelReady = $false
+                    } else {
+                        Write-Host "  Sentinel onboarding state present."
+                    }
                 }
             }
 
-            # If an optional separate playbook RG is configured via the
-            # PLAYBOOK_RESOURCE_GROUP repo variable, it must also exist —
-            # otherwise Stage 2 Bicep needs to create it via the
-            # conditional playbookRgName resource block in main.bicep.
-            # Trim defensively to survive accidental whitespace in the
-            # GitHub repo variable (a real user-facing footgun: a
-            # trailing space yields 'rg-name ' which Azure treats as a
-            # distinct, non-existent name).
+            # ── Optional playbook RG ────────────────────────────────
+            # Trim defensively to survive accidental whitespace in
+            # the GitHub repo variable.
             $playbookRG = "${{ vars.PLAYBOOK_RESOURCE_GROUP }}".Trim()
             if ($playbookRG -and $playbookRG -ne "${{ env.RESOURCE_GROUP }}") {
                 $pbRg = Get-AzResourceGroup -Name $playbookRG -ErrorAction SilentlyContinue
                 if (-not $pbRg) {
-                    Write-Host "Playbook RG '$playbookRG' not found — Bicep deployment required."
-                    $resourcesExist = "false"
+                    Write-Host "  Playbook RG '$playbookRG' missing."
+                    $playbookRgReady = $false
                 } else {
-                    Write-Host "Playbook RG '$playbookRG' exists."
+                    Write-Host "  Playbook RG '$playbookRG' exists."
                 }
             }
 
-            if ($resourcesExist -eq "true") {
-                Write-Host "All required infrastructure present — skipping Bicep."
-            }
+            # ── Decision matrix ─────────────────────────────────────
+            $bicepNeeded    = (-not $sentinelReady) -or (-not $playbookRgReady)
+            $deploySentinel = -not $sentinelReady
 
-            echo "resources_exist=$resourcesExist" >> $env:GITHUB_OUTPUT
+            Write-Host ""
+            Write-Host "Stage 2 decision:"
+            Write-Host ("  bicep_needed    = " + $bicepNeeded.ToString().ToLower())
+            Write-Host ("  deploy_sentinel = " + $deploySentinel.ToString().ToLower())
+
+            "bicep_needed=$($bicepNeeded.ToString().ToLower())"       | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "deploy_sentinel=$($deploySentinel.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
   # ===========================================================================
   # Stage 2: Deploy Infrastructure (Bicep)
@@ -229,7 +262,7 @@ jobs:
     if: |
       always() &&
       needs.check-infrastructure.result == 'success' &&
-      needs.check-infrastructure.outputs.resources_exist == 'false'
+      needs.check-infrastructure.outputs.bicep_needed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -285,7 +318,8 @@ jobs:
                 dailyQuota=${{ inputs.daily_quota || 0 }} \
                 retentionInDays=${{ inputs.retention_in_days || 90 }} \
                 totalRetentionInDays=${{ inputs.total_retention_in_days || 0 }} \
-                playbookRgName="$PLAYBOOK_RG"
+                playbookRgName="$PLAYBOOK_RG" \
+                deploySentinel=${{ needs.check-infrastructure.outputs.deploy_sentinel }}
 
       - name: Wait for Workspace Indexing
         shell: pwsh

--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -270,14 +270,14 @@ jobs:
                         # Deploying with deploySentinel=false would
                         # leave the OMS solution unrepaired. An
                         # operator must intervene before proceeding.
-                        Write-Host "##[error]Unrecoverable partial Sentinel onboarding state on workspace '${{ env.WORKSPACE_NAME }}':"
-                        Write-Host "##[error]  - Present: Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)"
-                        Write-Host "##[error]  - Missing: OMS Sentinel solution (Microsoft.OperationsManagement/solutions/SecurityInsights(${{ env.WORKSPACE_NAME }}))"
-                        Write-Host "##[error]The non-idempotent onboardingStates resource survived but the OMS solution was deleted out of band. The deploy pipeline cannot reconcile this state automatically: re-running with deploySentinel=true would return Conflict on the surviving onboardingStates resource, and deploySentinel=false would leave the OMS solution unrepaired."
-                        Write-Host "##[error]Resolution options:"
-                        Write-Host "##[error]  1. Delete the surviving onboardingStates/default resource via the Azure portal and re-run this workflow (Bicep will then create both fresh)."
-                        Write-Host "##[error]  2. Manually create the missing OMS solution via portal or an ad-hoc Bicep deploy targeting only that resource."
-                        Write-Host "##[error]Background: Docs/Deployment/Bicep.md 'Why two onboarding mechanisms?'."
+                        Write-Host "::error::Unrecoverable partial Sentinel onboarding state on workspace '${{ env.WORKSPACE_NAME }}':"
+                        Write-Host "::error::  - Present: Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)"
+                        Write-Host "::error::  - Missing: OMS Sentinel solution (Microsoft.OperationsManagement/solutions/SecurityInsights(${{ env.WORKSPACE_NAME }}))"
+                        Write-Host "::error::The non-idempotent onboardingStates resource survived but the OMS solution was deleted out of band. The deploy pipeline cannot reconcile this state automatically: re-running with deploySentinel=true would return Conflict on the surviving onboardingStates resource, and deploySentinel=false would leave the OMS solution unrepaired."
+                        Write-Host "::error::Resolution options:"
+                        Write-Host "::error::  1. Delete the surviving onboardingStates/default resource via the Azure portal and re-run this workflow (Bicep will then create both fresh)."
+                        Write-Host "::error::  2. Manually create the missing OMS solution via portal or an ad-hoc Bicep deploy targeting only that resource."
+                        Write-Host "::error::Background: Docs/Deployment/Bicep.md 'Why two onboarding mechanisms?'."
                         throw "Unrecoverable partial Sentinel onboarding state - aborting deploy."
                     }
                 }
@@ -546,8 +546,8 @@ jobs:
         run: |
           & "${{ github.workspace }}/Scripts/Build-DependencyManifest.ps1" -Mode Verify -RepoPath "${{ github.workspace }}"
           if ($LASTEXITCODE -ne 0) {
-              Write-Host "##[error]dependencies.json is out of sync. Refusing to deploy with a stale dependency graph."
-              Write-Host "##[error]Fix: run ./Scripts/Build-DependencyManifest.ps1 -Mode Generate, commit, then re-run this workflow."
+              Write-Host "::error::dependencies.json is out of sync. Refusing to deploy with a stale dependency graph."
+              Write-Host "::error::Fix: run ./Scripts/Build-DependencyManifest.ps1 -Mode Generate, commit, then re-run this workflow."
               exit 1
           }
 

--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -230,32 +230,55 @@ jobs:
                     $onboardingId = "/subscriptions/$subId/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.OperationalInsights/workspaces/${{ env.WORKSPACE_NAME }}/providers/Microsoft.SecurityInsights/onboardingStates/default"
                     $onboarding = Get-AzResource -ResourceId $onboardingId -ApiVersion "2024-09-01" -ErrorAction SilentlyContinue
 
+                    # Three-case truth table over the two onboarding
+                    # resources. The asymmetric handling of the two
+                    # "exactly one missing" cases reflects which
+                    # resource is non-idempotent:
+                    #
+                    #   - The OMS solution is idempotent on re-deploy
+                    #     (the Bicep template comment calls this out
+                    #     explicitly). Deploying it when it already
+                    #     exists is a no-op.
+                    #   - The onboardingStates resource is NOT
+                    #     idempotent. Deploying it when it already
+                    #     exists returns Conflict.
+                    #
+                    # Therefore: an "OMS missing, state survives"
+                    # state cannot be auto-repaired by re-running
+                    # Bicep (state would Conflict). An "OMS survives,
+                    # state missing" state CAN be auto-repaired
+                    # (state gets created fresh; OMS re-deploy is a
+                    # no-op).
                     if ($omsSolution -and $onboarding) {
                         Write-Host "  Sentinel fully onboarded (OMS solution + onboarding state)."
                     } elseif (-not $omsSolution -and -not $onboarding) {
                         Write-Host "  Sentinel not onboarded (neither OMS solution nor onboarding state)."
                         $sentinelReady = $false
+                    } elseif ($omsSolution -and -not $onboarding) {
+                        # Auto-repairable: state is the non-idempotent
+                        # resource, and it's the one that's missing.
+                        # Re-running the sentinel module will create
+                        # it without Conflict; the surviving OMS
+                        # solution re-deploys idempotently.
+                        Write-Host "  Partial onboarding detected: OMS solution present, onboarding state missing."
+                        Write-Host "  Auto-repairing by re-running the Sentinel module (state is the non-idempotent resource and is the one missing)."
+                        $sentinelReady = $false
                     } else {
-                        # Inconsistent state: one onboarding resource
-                        # exists, the other doesn't. Running Bicep with
-                        # deploySentinel=true would Conflict on the
-                        # surviving onboardingStates resource (or
-                        # silently no-op on the surviving solution).
-                        # Running with deploySentinel=false would leave
-                        # the gap unrepaired. The deploy cannot
-                        # reconcile this state automatically; an
+                        # Unrecoverable: the surviving onboardingStates
+                        # resource is non-idempotent. Deploying with
+                        # deploySentinel=true would Conflict on it.
+                        # Deploying with deploySentinel=false would
+                        # leave the OMS solution unrepaired. An
                         # operator must intervene before proceeding.
-                        $present = if ($omsSolution) { 'OMS Sentinel solution (Microsoft.OperationsManagement/solutions)' } else { 'Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)' }
-                        $missing = if (-not $omsSolution) { 'OMS Sentinel solution (Microsoft.OperationsManagement/solutions)' } else { 'Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)' }
-                        Write-Host "##[error]Inconsistent Sentinel onboarding state on workspace '${{ env.WORKSPACE_NAME }}':"
-                        Write-Host "##[error]  - Present: $present"
-                        Write-Host "##[error]  - Missing: $missing"
-                        Write-Host "##[error]This workspace was partially onboarded (or had one of the two onboarding resources deleted out of band). The deploy pipeline cannot reconcile this state automatically."
+                        Write-Host "##[error]Unrecoverable partial Sentinel onboarding state on workspace '${{ env.WORKSPACE_NAME }}':"
+                        Write-Host "##[error]  - Present: Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)"
+                        Write-Host "##[error]  - Missing: OMS Sentinel solution (Microsoft.OperationsManagement/solutions/SecurityInsights(${{ env.WORKSPACE_NAME }}))"
+                        Write-Host "##[error]The non-idempotent onboardingStates resource survived but the OMS solution was deleted out of band. The deploy pipeline cannot reconcile this state automatically: re-running with deploySentinel=true would return Conflict on the surviving onboardingStates resource, and deploySentinel=false would leave the OMS solution unrepaired."
                         Write-Host "##[error]Resolution options:"
-                        Write-Host "##[error]  1. Delete the surviving onboarding resource via the Azure portal and re-run this workflow (Bicep will then create both fresh)."
-                        Write-Host "##[error]  2. Manually create the missing resource via portal or an ad-hoc Bicep deploy targeting only the missing resource."
+                        Write-Host "##[error]  1. Delete the surviving onboardingStates/default resource via the Azure portal and re-run this workflow (Bicep will then create both fresh)."
+                        Write-Host "##[error]  2. Manually create the missing OMS solution via portal or an ad-hoc Bicep deploy targeting only that resource."
                         Write-Host "##[error]Background: Docs/Deployment/Bicep.md 'Why two onboarding mechanisms?'."
-                        throw "Inconsistent Sentinel onboarding state — aborting deploy."
+                        throw "Unrecoverable partial Sentinel onboarding state - aborting deploy."
                     }
                 }
             }

--- a/.github/workflows/sentinel-deploy.yml
+++ b/.github/workflows/sentinel-deploy.yml
@@ -210,18 +210,52 @@ jobs:
                 } else {
                     Write-Host "  Workspace '${{ env.WORKSPACE_NAME }}' exists."
 
-                    # Sentinel onboarding state is the non-idempotent
-                    # resource that causes Conflict on re-deploy.
-                    # Treat its existence as the canonical "Sentinel
-                    # is onboarded" signal.
+                    # Sentinel uses a dual onboarding pattern (see
+                    # Docs/Deployment/Bicep.md "Why two onboarding
+                    # mechanisms?"): the legacy
+                    # Microsoft.OperationsManagement/solutions
+                    # SecurityInsights(<workspace>) resource AND the
+                    # modern Microsoft.SecurityInsights/onboardingStates
+                    # /default resource. Bicep/sentinel.bicep deploys
+                    # both. Both must exist for the workspace to be
+                    # considered fully onboarded. Probe both
+                    # independently so a partially-deleted onboarding
+                    # state (one survives, the other is gone) is
+                    # surfaced explicitly rather than silently skipped.
                     $subId = (Get-AzContext).Subscription.Id
+
+                    $omsSolutionId = "/subscriptions/$subId/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.OperationsManagement/solutions/SecurityInsights(${{ env.WORKSPACE_NAME }})"
+                    $omsSolution = Get-AzResource -ResourceId $omsSolutionId -ApiVersion "2015-11-01-preview" -ErrorAction SilentlyContinue
+
                     $onboardingId = "/subscriptions/$subId/resourceGroups/${{ env.RESOURCE_GROUP }}/providers/Microsoft.OperationalInsights/workspaces/${{ env.WORKSPACE_NAME }}/providers/Microsoft.SecurityInsights/onboardingStates/default"
                     $onboarding = Get-AzResource -ResourceId $onboardingId -ApiVersion "2024-09-01" -ErrorAction SilentlyContinue
-                    if (-not $onboarding) {
-                        Write-Host "  Sentinel onboarding state missing."
+
+                    if ($omsSolution -and $onboarding) {
+                        Write-Host "  Sentinel fully onboarded (OMS solution + onboarding state)."
+                    } elseif (-not $omsSolution -and -not $onboarding) {
+                        Write-Host "  Sentinel not onboarded (neither OMS solution nor onboarding state)."
                         $sentinelReady = $false
                     } else {
-                        Write-Host "  Sentinel onboarding state present."
+                        # Inconsistent state: one onboarding resource
+                        # exists, the other doesn't. Running Bicep with
+                        # deploySentinel=true would Conflict on the
+                        # surviving onboardingStates resource (or
+                        # silently no-op on the surviving solution).
+                        # Running with deploySentinel=false would leave
+                        # the gap unrepaired. The deploy cannot
+                        # reconcile this state automatically; an
+                        # operator must intervene before proceeding.
+                        $present = if ($omsSolution) { 'OMS Sentinel solution (Microsoft.OperationsManagement/solutions)' } else { 'Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)' }
+                        $missing = if (-not $omsSolution) { 'OMS Sentinel solution (Microsoft.OperationsManagement/solutions)' } else { 'Sentinel onboarding state (Microsoft.SecurityInsights/onboardingStates/default)' }
+                        Write-Host "##[error]Inconsistent Sentinel onboarding state on workspace '${{ env.WORKSPACE_NAME }}':"
+                        Write-Host "##[error]  - Present: $present"
+                        Write-Host "##[error]  - Missing: $missing"
+                        Write-Host "##[error]This workspace was partially onboarded (or had one of the two onboarding resources deleted out of band). The deploy pipeline cannot reconcile this state automatically."
+                        Write-Host "##[error]Resolution options:"
+                        Write-Host "##[error]  1. Delete the surviving onboarding resource via the Azure portal and re-run this workflow (Bicep will then create both fresh)."
+                        Write-Host "##[error]  2. Manually create the missing resource via portal or an ad-hoc Bicep deploy targeting only the missing resource."
+                        Write-Host "##[error]Background: Docs/Deployment/Bicep.md 'Why two onboarding mechanisms?'."
+                        throw "Inconsistent Sentinel onboarding state — aborting deploy."
                     }
                 }
             }

--- a/Bicep/main.bicep
+++ b/Bicep/main.bicep
@@ -35,7 +35,7 @@ param totalRetentionInDays int = 0
 @description('Optional separate Resource Group for playbooks/Logic Apps. If empty, playbooks deploy to the main RG.')
 param playbookRgName string = ''
 
-@description('Whether to (re)deploy the Sentinel module. Set false by the workflow when Sentinel onboarding already exists on the target workspace — the Microsoft.SecurityInsights/onboardingStates resource is not idempotent and re-deploying it returns Conflict. False allows main.bicep to provision only the missing pieces (most commonly the optional playbook RG) without touching an existing Sentinel deployment.')
+@description('Whether to (re)deploy the Sentinel module. Set false by the deployment pipeline (GitHub Actions or Azure DevOps) when Sentinel onboarding already exists on the target workspace; the Microsoft.SecurityInsights/onboardingStates resource is not idempotent and re-deploying it returns Conflict. False allows main.bicep to provision only the missing pieces (most commonly the optional playbook RG) without touching an existing Sentinel deployment.')
 param deploySentinel bool = true
 
 @description('Resource tags applied to all resources.')
@@ -81,13 +81,19 @@ module sentinel 'sentinel.bicep' = if (deploySentinel) {
 // Outputs
 // -----------------------------------------------------------------------
 
-// Outputs collapse to empty values when the sentinel module was
-// skipped (deploySentinel = false). Downstream pipeline stages read
-// workspace identifiers from GitHub repo variables rather than from
-// these outputs, so the empty-fallback path is non-breaking. The `.?`
-// safe-access + `??` default-coalesce pattern is used instead of a
-// ternary so Bicep can statically prove the access path is safe (a
-// plain ternary trips BCP318 because the analyzer can't tie the
-// guard expression to the module's nullability).
+// When the sentinel module is skipped (deploySentinel = false), the
+// downstream resourceId / workspace outputs are not meaningful. To
+// give consumers a clean way to distinguish "module skipped" from
+// "module ran but produced an empty value", a sentinelDeployed
+// boolean is emitted alongside.
+//
+// The resourceId / workspace outputs use the `.?` safe-access plus
+// `??` default-coalesce pattern instead of a ternary so Bicep can
+// statically prove the access path is safe (a plain
+// `deploySentinel ? sentinel.outputs.X : ''` ternary trips BCP318 -
+// the analyzer can't tie the guard expression to the module's
+// nullability). Consumers should branch on sentinelDeployed rather
+// than testing the resourceId for emptiness.
+output sentinelDeployed bool = deploySentinel
 output sentinelResourceId string = sentinel.?outputs.sentinelResourceId ?? ''
 output logAnalyticsWorkspace object = sentinel.?outputs.logAnalyticsWorkspace ?? {}

--- a/Bicep/main.bicep
+++ b/Bicep/main.bicep
@@ -35,6 +35,9 @@ param totalRetentionInDays int = 0
 @description('Optional separate Resource Group for playbooks/Logic Apps. If empty, playbooks deploy to the main RG.')
 param playbookRgName string = ''
 
+@description('Whether to (re)deploy the Sentinel module. Set false by the workflow when Sentinel onboarding already exists on the target workspace — the Microsoft.SecurityInsights/onboardingStates resource is not idempotent and re-deploying it returns Conflict. False allows main.bicep to provision only the missing pieces (most commonly the optional playbook RG) without touching an existing Sentinel deployment.')
+param deploySentinel bool = true
+
 @description('Resource tags applied to all resources.')
 param tags object = {}
 
@@ -62,7 +65,7 @@ resource playbookRg 'Microsoft.Resources/resourceGroups@2024-07-01' = if (!empty
 // Sentinel Module
 // -----------------------------------------------------------------------
 
-module sentinel 'sentinel.bicep' = {
+module sentinel 'sentinel.bicep' = if (deploySentinel) {
   scope: rg
   name: 'sentinelDeployment'
   params: {
@@ -78,5 +81,13 @@ module sentinel 'sentinel.bicep' = {
 // Outputs
 // -----------------------------------------------------------------------
 
-output sentinelResourceId string = sentinel.outputs.sentinelResourceId
-output logAnalyticsWorkspace object = sentinel.outputs.logAnalyticsWorkspace
+// Outputs collapse to empty values when the sentinel module was
+// skipped (deploySentinel = false). Downstream pipeline stages read
+// workspace identifiers from GitHub repo variables rather than from
+// these outputs, so the empty-fallback path is non-breaking. The `.?`
+// safe-access + `??` default-coalesce pattern is used instead of a
+// ternary so Bicep can statically prove the access path is safe (a
+// plain ternary trips BCP318 because the analyzer can't tie the
+// guard expression to the module's nullability).
+output sentinelResourceId string = sentinel.?outputs.sentinelResourceId ?? ''
+output logAnalyticsWorkspace object = sentinel.?outputs.logAnalyticsWorkspace ?? {}

--- a/Bicep/main.bicep
+++ b/Bicep/main.bicep
@@ -95,5 +95,5 @@ module sentinel 'sentinel.bicep' = if (deploySentinel) {
 // nullability). Consumers should branch on sentinelDeployed rather
 // than testing the resourceId for emptiness.
 output sentinelDeployed bool = deploySentinel
-output sentinelResourceId string = sentinel.?outputs.sentinelResourceId ?? ''
-output logAnalyticsWorkspace object = sentinel.?outputs.logAnalyticsWorkspace ?? {}
+output sentinelResourceId string = sentinel.?outputs.?sentinelResourceId ?? ''
+output logAnalyticsWorkspace object = sentinel.?outputs.?logAnalyticsWorkspace ?? {}

--- a/Bicep/main.bicep
+++ b/Bicep/main.bicep
@@ -84,16 +84,21 @@ module sentinel 'sentinel.bicep' = if (deploySentinel) {
 // When the sentinel module is skipped (deploySentinel = false), the
 // downstream resourceId / workspace outputs are not meaningful. To
 // give consumers a clean way to distinguish "module skipped" from
-// "module ran but produced an empty value", a sentinelDeployed
-// boolean is emitted alongside.
+// "module ran but produced an empty value", a sentinelModuleEnabled
+// boolean is emitted alongside. The name reflects what the value
+// actually represents: it echoes the deploySentinel input parameter
+// (was the module enabled this run?), NOT a post-deploy success
+// signal (was Sentinel actually deployed?). Consumers wanting a
+// success signal should test sentinelResourceId for non-emptiness
+// in combination with this flag.
 //
 // The resourceId / workspace outputs use the `.?` safe-access plus
 // `??` default-coalesce pattern instead of a ternary so Bicep can
 // statically prove the access path is safe (a plain
 // `deploySentinel ? sentinel.outputs.X : ''` ternary trips BCP318 -
 // the analyzer can't tie the guard expression to the module's
-// nullability). Consumers should branch on sentinelDeployed rather
-// than testing the resourceId for emptiness.
-output sentinelDeployed bool = deploySentinel
+// nullability). Consumers should branch on sentinelModuleEnabled
+// rather than testing the resourceId for emptiness.
+output sentinelModuleEnabled bool = deploySentinel
 output sentinelResourceId string = sentinel.?outputs.?sentinelResourceId ?? ''
 output logAnalyticsWorkspace object = sentinel.?outputs.?logAnalyticsWorkspace ?? {}

--- a/Docs/Deployment/Bicep.md
+++ b/Docs/Deployment/Bicep.md
@@ -144,7 +144,7 @@ az deployment sub create \
 
 Stage 1 first checks whether the resource group + workspace already exist, and skips Stage 2 entirely when they do — see [Pipelines](Pipelines.md) for the conditional logic.
 
-`deploySentinel` defaults to `true` and is omitted by the ADO pipeline today (it relies on the default). The GitHub Actions workflow's Stage 1 runs a finer per-component probe and passes `deploySentinel=false` when Sentinel is already onboarded but other infrastructure (most commonly the optional playbook RG) is missing — this lets Bicep provision only the gap without re-attempting the non-idempotent `Microsoft.SecurityInsights/onboardingStates` resource. ADO porting is tracked under [`instructions/workflows.instructions.md`](../../.github/instructions/workflows.instructions.md) Hard rule 1 ("one-direction-first bug fixes").
+`deploySentinel` defaults to `true` and is omitted by the ADO pipeline today (it relies on the default). The GitHub Actions workflow's Stage 1 runs a finer per-component probe and passes `deploySentinel=false` when Sentinel is already onboarded but other infrastructure (most commonly the optional playbook RG) is missing — this lets Bicep provision only the gap without re-attempting the non-idempotent `Microsoft.SecurityInsights/onboardingStates` resource. ADO porting is allowed per [`instructions/workflows.instructions.md`](../../.github/instructions/workflows.instructions.md) Hard rule 1 ("one-direction-first bug fixes").
 
 ## Settings configured outside Bicep
 

--- a/Docs/Deployment/Bicep.md
+++ b/Docs/Deployment/Bicep.md
@@ -138,9 +138,10 @@ az deployment sub create \
         dailyQuota=${{ parameters.dailyQuota }} \
         retentionInDays=${{ parameters.retentionInDays }} \
         totalRetentionInDays=${{ parameters.totalRetentionInDays }} \
-        playbookRgName=$(playbookResourceGroup) \
-        deploySentinel=true
+        playbookRgName=$(playbookResourceGroup)
 ```
+
+`deploySentinel` is intentionally omitted from this ADO invocation — see the paragraph below for the asymmetric handling between platforms.
 
 Stage 1 first checks for existing infrastructure and skips Stage 2 entirely when everything required is already present — see [Pipelines](Pipelines.md) for the conditional logic. The two pipelines differ in probe granularity:
 

--- a/Docs/Deployment/Bicep.md
+++ b/Docs/Deployment/Bicep.md
@@ -42,8 +42,8 @@ Subscription-scoped orchestrator. Creates the main resource group, an optional s
 
 | Output | Type | Source / behaviour |
 | --- | --- | --- |
-| `sentinelDeployed` | bool | Echoes the `deploySentinel` parameter. Consumers should branch on this before reading `sentinelResourceId` / `logAnalyticsWorkspace` — those values are only meaningful when `sentinelDeployed = true` |
-| `sentinelResourceId` | string | Bubbled up from the Sentinel module — the OMS solution resource ID. Collapses to `''` when `deploySentinel = false` (module skipped); use `sentinelDeployed` to distinguish "module skipped" from "module ran and produced an empty string" |
+| `sentinelModuleEnabled` | bool | Echoes the `deploySentinel` input parameter — reports whether the Sentinel module was *enabled* on this run, not whether Sentinel was successfully *deployed*. Consumers should branch on this before reading `sentinelResourceId` / `logAnalyticsWorkspace`; for an end-to-end "Sentinel is deployed" signal, combine this flag with a non-empty `sentinelResourceId` |
+| `sentinelResourceId` | string | Bubbled up from the Sentinel module — the OMS solution resource ID. Collapses to `''` when `deploySentinel = false` (module skipped); use `sentinelModuleEnabled` to distinguish "module skipped" from "module ran and produced an empty string" |
 | `logAnalyticsWorkspace` | object | Bubbled up from the Sentinel module — `{ name, id, location, retentionInDays }`. Collapses to `{}` when `deploySentinel = false` (same caveat as above) |
 
 ## sentinel.bicep
@@ -142,7 +142,10 @@ az deployment sub create \
         deploySentinel=true
 ```
 
-Stage 1 first checks whether the resource group + workspace already exist, and skips Stage 2 entirely when they do — see [Pipelines](Pipelines.md) for the conditional logic.
+Stage 1 first checks for existing infrastructure and skips Stage 2 entirely when everything required is already present — see [Pipelines](Pipelines.md) for the conditional logic. The two pipelines differ in probe granularity:
+
+- **ADO** checks the resource group and workspace only.
+- **GitHub Actions** additionally probes both Sentinel onboarding resources (`Microsoft.OperationsManagement/solutions` *and* `Microsoft.SecurityInsights/onboardingStates/default`) and the optional separate playbook RG. When Sentinel is fully onboarded but the playbook RG is missing, GH passes `deploySentinel=false` to Bicep so the Sentinel module is skipped and only the playbook RG is provisioned.
 
 `deploySentinel` defaults to `true` and is omitted by the ADO pipeline today (it relies on the default). The GitHub Actions workflow's Stage 1 runs a finer per-component probe and passes `deploySentinel=false` when Sentinel is already onboarded but other infrastructure (most commonly the optional playbook RG) is missing — this lets Bicep provision only the gap without re-attempting the non-idempotent `Microsoft.SecurityInsights/onboardingStates` resource. ADO porting is allowed per [`instructions/workflows.instructions.md`](../../.github/instructions/workflows.instructions.md) Hard rule 1 ("one-direction-first bug fixes").
 

--- a/Docs/Deployment/Bicep.md
+++ b/Docs/Deployment/Bicep.md
@@ -138,10 +138,13 @@ az deployment sub create \
         dailyQuota=${{ parameters.dailyQuota }} \
         retentionInDays=${{ parameters.retentionInDays }} \
         totalRetentionInDays=${{ parameters.totalRetentionInDays }} \
-        playbookRgName=$(playbookResourceGroup)
+        playbookRgName=$(playbookResourceGroup) \
+        deploySentinel=true
 ```
 
 Stage 1 first checks whether the resource group + workspace already exist, and skips Stage 2 entirely when they do — see [Pipelines](Pipelines.md) for the conditional logic.
+
+`deploySentinel` defaults to `true` and is omitted by the ADO pipeline today (it relies on the default). The GitHub Actions workflow's Stage 1 runs a finer per-component probe and passes `deploySentinel=false` when Sentinel is already onboarded but other infrastructure (most commonly the optional playbook RG) is missing — this lets Bicep provision only the gap without re-attempting the non-idempotent `Microsoft.SecurityInsights/onboardingStates` resource. ADO porting is tracked under [`instructions/workflows.instructions.md`](../../.github/instructions/workflows.instructions.md) Hard rule 1 ("one-direction-first bug fixes").
 
 ## Settings configured outside Bicep
 

--- a/Docs/Deployment/Bicep.md
+++ b/Docs/Deployment/Bicep.md
@@ -27,6 +27,7 @@ Subscription-scoped orchestrator. Creates the main resource group, an optional s
 | `retentionInDays` | int | `90` | 30-730 | Interactive retention period |
 | `totalRetentionInDays` | int | `0` | 0-2555 | Total retention including archive tier. `0` = use platform default (matches `retentionInDays`) |
 | `playbookRgName` | string | `''` | — | Optional separate Resource Group for playbooks/Logic Apps. Empty or equal to `rgName` means playbooks land in the main RG |
+| `deploySentinel` | bool | `true` | — | Whether to deploy the `sentinel.bicep` module. Set `false` by the deployment pipeline when Sentinel onboarding already exists on the target workspace; the `Microsoft.SecurityInsights/onboardingStates` resource is not idempotent and re-deploying it returns `Conflict`. Setting `false` lets `main.bicep` provision only the missing pieces (most commonly the optional playbook RG) without touching an existing Sentinel deployment |
 | `tags` | object | `{}` | — | Resource tags applied to all resources |
 
 ### Resources created
@@ -35,13 +36,15 @@ Subscription-scoped orchestrator. Creates the main resource group, an optional s
 | --- | --- | --- |
 | `Microsoft.Resources/resourceGroups` (main) | `2024-07-01` | Always created |
 | `Microsoft.Resources/resourceGroups` (playbook) | `2024-07-01` | Conditional — only when `playbookRgName` is non-empty AND differs from `rgName` |
+| `sentinel.bicep` module | n/a | Conditional — invoked only when `deploySentinel = true`. Skipped on targeted partial deploys (e.g. provisioning a missing playbook RG while leaving an already-onboarded Sentinel workspace untouched) |
 
 ### Outputs
 
-| Output | Type | Source |
+| Output | Type | Source / behaviour |
 | --- | --- | --- |
-| `sentinelResourceId` | string | Bubbled up from the Sentinel module — the OMS solution resource ID |
-| `logAnalyticsWorkspace` | object | Bubbled up from the Sentinel module — `{ name, id, location, retentionInDays }` |
+| `sentinelDeployed` | bool | Echoes the `deploySentinel` parameter. Consumers should branch on this before reading `sentinelResourceId` / `logAnalyticsWorkspace` — those values are only meaningful when `sentinelDeployed = true` |
+| `sentinelResourceId` | string | Bubbled up from the Sentinel module — the OMS solution resource ID. Collapses to `''` when `deploySentinel = false` (module skipped); use `sentinelDeployed` to distinguish "module skipped" from "module ran and produced an empty string" |
+| `logAnalyticsWorkspace` | object | Bubbled up from the Sentinel module — `{ name, id, location, retentionInDays }`. Collapses to `{}` when `deploySentinel = false` (same caveat as above) |
 
 ## sentinel.bicep
 


### PR DESCRIPTION
## Summary

Fixes the `Conflict` error on Stage 2 when only the optional playbook RG is missing. Today the Bicep call is non-conditional — any time Stage 1 reports "not current", the entire Sentinel module re-runs, which fails because `Microsoft.SecurityInsights/onboardingStates` is non-idempotent and rejects re-creation against an already-onboarded workspace:

```
Code:   DeploymentFailed
Inner:  ResourceDeploymentFailure → Conflict
Target: <rg>/providers/Microsoft.Resources/deployments/sentinelDeployment
```

Result: the deploy aborts before the playbook RG is provisioned, leaving the user in exactly the broken state Bicep was meant to fix.

## Fix

Make Stage 2 conditional per-component:

- **Bicep** — new `deploySentinel` parameter gates the entire `sentinel` module. Defaults `true`, but the workflow passes `false` when Sentinel onboarding already exists.
- **Workflow Stage 1** — granular probe outputs two flags instead of one boolean:
  - `bicep_needed` — controls whether Stage 2 runs at all
  - `deploy_sentinel` — controls whether Bicep runs the Sentinel module
- **Workflow Stage 2** — gate updated and the new flag forwarded to Bicep

## Decision matrix (post-change)

| Scenario | `bicep_needed` | `deploy_sentinel` | What Bicep does |
|---|:---:|:---:|---|
| Clean install (nothing exists) | true | true | Creates RG + workspace + Sentinel + playbook RG |
| Sentinel onboarded, **playbook RG missing** (your current case) | true | false | Creates **only** the playbook RG; Sentinel module skipped |
| Sentinel onboarded + playbook RG present | false | — | Stage 2 skipped entirely (existing behaviour) |
| Anomalous: workspace exists, Sentinel not onboarded | true | true | Workspace resource is idempotent so updates; onboarding created fresh |

## Files changed

| File | Change |
|---|---|
| `Bicep/main.bicep` | New `deploySentinel` param; module gated `if (deploySentinel)`; outputs converted to `.?` safe-access + `??` default-coalesce to clear BCP318 warnings |
| `.github/workflows/sentinel-deploy.yml` | Stage 1 probes Sentinel onboarding state directly via `Microsoft.SecurityInsights/onboardingStates`; outputs two granular flags; Stage 2 reads them; Bicep call appends `deploySentinel=<flag>` |

## Validation

- ✅ `powershell-yaml` 0.4.12 round-trip on the workflow — parses cleanly
- ✅ `bicep build Bicep/main.bicep` — zero warnings, zero errors (the BCP318 from the first ternary draft was fixed via the `.?` + `??` rewrite)

## Test plan

- [ ] PR-validation gate passes (Pester, Bicep build, ARM What-If, KQL syntax, dependency-manifest drift)
- [ ] After merge, re-trigger the previously failing Deploy Sentinel run — Stage 1 reports `deploy_sentinel = false`, Stage 2 invokes Bicep with `deploySentinel=false`, only the playbook RG gets created, no Conflict on Sentinel onboarding
- [ ] Trigger a Deploy Sentinel run against a workspace where everything already exists — Stage 1 reports `bicep_needed = false` and Stage 2 is skipped (existing behaviour preserved)

## Out of scope

`Pipelines/Sentinel-Deploy.yml` (ADO) — has the same architectural issue but is intentionally not modified per the maintainer's earlier guidance. The fix shape would mirror this PR exactly if a future ADO parity pass is desired.