### PR TITLE
fix(workbooks): anchor SDL export default output to $PSScriptRoot

### DIFF
--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -900,6 +900,9 @@ if (-not $OutputPath) {
     # an absolute path. $PSScriptRoot is always the script's own folder.
     $OutputPath = Join-Path $PSScriptRoot "SdlMigrationExport_${WorkspaceName}_${stamp}.xlsx"
 }
+if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:\\') {
+    throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on this platform. Use a POSIX path instead."
+}
 $outputDir = Split-Path -Parent $OutputPath
 if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
 if (Test-Path -LiteralPath $OutputPath) { Remove-Item -LiteralPath $OutputPath -Force }

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -919,7 +919,7 @@ if (-not $OutputPath) {
 if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
     throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on this platform. Use a POSIX path instead."
 }
-$outputDir = Split-Path -Parent $OutputPath
+$outputDir = Split-Path -LiteralPath $OutputPath -Parent
 if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -LiteralPath $outputDir -Force | Out-Null }
 if (Test-Path -LiteralPath $OutputPath) { Remove-Item -LiteralPath $OutputPath -Force }
 

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -920,7 +920,7 @@ if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
     throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on this platform. Use a POSIX path instead."
 }
 $outputDir = Split-Path -Parent $OutputPath
-if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -LiteralPath $outputDir -Force | Out-Null }
 if (Test-Path -LiteralPath $OutputPath) { Remove-Item -LiteralPath $OutputPath -Force }
 
 Write-Host ""

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -43,7 +43,9 @@
 
 .PARAMETER OutputPath
     Path for the output .xlsx. Defaults to
-    SdlMigrationExport_<workspace>_<yyyyMMdd-HHmm>.xlsx in the current directory.
+    SdlMigrationExport_<workspace>_<yyyyMMdd-HHmm>.xlsx alongside the script
+    ($PSScriptRoot), so the file lands in a predictable location regardless
+    of the caller's current working directory.
 
 .PARAMETER TimeRangeDays
     Ingestion analysis window. Default: 30. Matches the workbook's TimeRange.
@@ -891,7 +893,12 @@ $pricingAssumptions = [pscustomobject]@{
 
 if (-not $OutputPath) {
     $stamp = $script:Now.ToString('yyyyMMdd-HHmm')
-    $OutputPath = Join-Path (Get-Location) "SdlMigrationExport_${WorkspaceName}_${stamp}.xlsx"
+    # Anchor the default output beside the script itself ($PSScriptRoot)
+    # rather than Get-Location. Get-Location depends on the caller's
+    # current working directory, which makes "where did the export go?"
+    # confusing when the script is launched from a parent folder or via
+    # an absolute path. $PSScriptRoot is always the script's own folder.
+    $OutputPath = Join-Path $PSScriptRoot "SdlMigrationExport_${WorkspaceName}_${stamp}.xlsx"
 }
 $outputDir = Split-Path -Parent $OutputPath
 if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -917,7 +917,7 @@ if (-not $OutputPath) {
 # plausibly appear in a copied example. The guard only fires on
 # non-Windows; Windows drive paths are perfectly valid on Windows.
 if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
-    throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on this platform. Use a POSIX path instead."
+    throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on macOS/Linux. Use a forward-slash path instead, e.g. '/tmp/report.xlsx' or './report.xlsx'."
 }
 $outputDir = Split-Path -LiteralPath $OutputPath -Parent
 if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -LiteralPath $outputDir -Force | Out-Null }

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -106,10 +106,12 @@
         -PricingModel             CT200 `
         -Currency                 GBP `
         -EffectiveAnalyticsRate   2.18 `
-        -OutputPath               "C:\Reports\sentinel-lake-prod.xlsx"
+        -OutputPath               "./sentinel-lake-prod.xlsx"
 
     Export with a CT200 commitment tier model, GBP cost labels, and a
-    custom output path.
+    custom output path. Uses a POSIX relative path so the example
+    copy-pastes cleanly on Windows, macOS, and Linux; substitute any
+    absolute or relative path your environment prefers.
 
 .NOTES
     Authentication : Uses the current Az context (Connect-AzAccount).
@@ -900,7 +902,21 @@ if (-not $OutputPath) {
     # an absolute path. $PSScriptRoot is always the script's own folder.
     $OutputPath = Join-Path $PSScriptRoot "SdlMigrationExport_${WorkspaceName}_${stamp}.xlsx"
 }
-if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:\\') {
+# Defensive guard for explicit -OutputPath callers. The default-path
+# branch above is already safe because $PSScriptRoot resolves to a
+# POSIX path on non-Windows, but a user who copied a Windows-style
+# example like -OutputPath "C:\Reports\foo.xlsx" (or "C:/Reports/...")
+# and ran the script on macOS/Linux would otherwise hit Split-Path /
+# Test-Path / New-Item further down with the unhelpful message:
+#
+#     Cannot find drive. A drive with the name 'C' does not exist.
+#
+# Catch it upfront with a clearer, platform-aware error. The regex
+# matches both backslash (C:\) and forward-slash (C:/) drive-rooted
+# forms because PowerShell on Windows accepts both, so either could
+# plausibly appear in a copied example. The guard only fires on
+# non-Windows; Windows drive paths are perfectly valid on Windows.
+if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
     throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on this platform. Use a POSIX path instead."
 }
 $outputDir = Split-Path -Parent $OutputPath


### PR DESCRIPTION
## Summary
- Default `$OutputPath` for `Export-SdlMigrationWorkbook.ps1` now resolves to `$PSScriptRoot` instead of `(Get-Location)`, so the xlsx always lands beside the script regardless of the caller's working directory.
- Explicit `-OutputPath` calls that pass a Windows drive path on non-Windows now fail fast with a platform-aware, copy-pasteable error message instead of the cryptic `Cannot find drive` from `New-Item` downstream. The guard catches both `C:\…` and `C:/…` forms.
- The output-directory-resolution block is now literal-path-safe across the whole chain: `Test-Path` and `Remove-Item` keep their `-LiteralPath` usage (those cmdlets support it), while `Split-Path -Parent` and `New-Item -ItemType Directory` are replaced by `[System.IO.Path]::GetDirectoryName()` and `[System.IO.Directory]::CreateDirectory()` respectively. The two PowerShell cmdlets do not actually support `-LiteralPath` in combination with the parameters we need (`Split-Path -LiteralPath -Parent` lives in a different parameter set from `-Parent`; `New-Item` has no `-LiteralPath` parameter at all). Both bot-auto-applied "fixes" attempting to use `-LiteralPath` on those cmdlets were runtime-broken (parameter-set resolution errors) and were superseded by the .NET-API drop. macOS/Linux paths containing `[`, `]`, `*`, `?` (legal on those filesystems) are now handled correctly.
- The second `.EXAMPLE` block was updated to use a cross-platform relative path (`./sentinel-lake-prod.xlsx`) instead of `C:\Reports\…`, removing the original footgun at source.
- `.PARAMETER OutputPath` synopsis updated to document the new default and rationale.

## Test plan
- [ ] Run `./Export-SdlMigrationWorkbook.ps1 -SubscriptionId <sub> -ResourceGroupName <rg> -WorkspaceName <ws>` from a working directory other than `Workbooks/SentinelDataLake/` and confirm the xlsx lands beside the script.
- [ ] Run with an explicit POSIX `-OutputPath /tmp/foo.xlsx` and confirm the explicit path is still honoured.
- [ ] Run with `-OutputPath "C:\Reports\foo.xlsx"` on macOS/Linux and confirm the throw fires with the new platform-aware message containing concrete example paths.
- [ ] Run with `-OutputPath "C:/Reports/foo.xlsx"` on macOS/Linux and confirm the guard also catches the forward-slash form.
- [ ] Run with `-OutputPath "/Users/x/Projects [Archive]/foo.xlsx"` on macOS and confirm the bracketed parent directory is created correctly with no wildcard misbehaviour.
- [ ] Run with `-OutputPath "/tmp/report [v2].xlsx"` on macOS and confirm filenames containing wildcard chars work.
- [ ] Run on Windows with the same Windows-style paths and confirm the drive-path guard does **not** fire there.

## Review thread audit
All five Copilot review threads addressed:
- ✅ Original "PR over-claims" critique → addressed by `87b2a7f`.
- ✅ `New-Item` should use `-LiteralPath` → bot's `d554122` was broken (`New-Item` has no `-LiteralPath` parameter); proper fix uses `[System.IO.Directory]::CreateDirectory` in `55db75a`.
- ✅ `Split-Path -Parent` should use `-LiteralPath` → bot's `3646759` was broken (`-LiteralPath` and `-Parent` live in different parameter sets on `Split-Path`); proper fix uses `[System.IO.Path]::GetDirectoryName` in `6ab9d5e`.
- ✅ `$IsWindows` vs `RuntimeInformation` → declined with rationale on thread (PS7+ is enforced at lines 199-201, so `$IsWindows` is guaranteed defined; keeping the idiomatic form).
- ✅ Throw message "POSIX path" jargon → addressed by `a6a56f3` (new message names macOS/Linux explicitly and includes concrete examples).

## Commit history
- `59bcfa3` — default `-OutputPath` now anchors to `$PSScriptRoot`.
- `760380e` — initial Windows-drive-path guard on non-Windows (auto-applied).
- `87b2a7f` — guard rationale block + regex broadened to `C:/…` + `.EXAMPLE` no longer ships the footgun.
- `d554122` — `New-Item -ItemType Directory` switched to `-LiteralPath` (auto-applied) — **broken: `New-Item` has no `-LiteralPath` parameter; superseded by `55db75a`**.
- `3646759` — `Split-Path -Parent` switched to `-LiteralPath` (auto-applied) — **broken: `-LiteralPath` and `-Parent` live in different parameter sets on `Split-Path`; superseded by `6ab9d5e`**.
- `a6a56f3` — throw message reworded to drop "POSIX" jargon and include concrete `/tmp/report.xlsx` and `./report.xlsx` examples.
- `55db75a` — regression fix: replace the broken `New-Item -LiteralPath` call with `[System.IO.Directory]::CreateDirectory`.
- `6ab9d5e` — regression fix: replace the broken `Split-Path -LiteralPath -Parent` call with `[System.IO.Path]::GetDirectoryName`, with a unified rationale comment covering both .NET drops.