### PR TITLE
fix(workbooks): replace broken -LiteralPath calls in SDL export with .NET path APIs

### DIFF
--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -919,17 +919,24 @@ if (-not $OutputPath) {
 if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
     throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on macOS/Linux. Use a forward-slash path instead, e.g. '/tmp/report.xlsx' or './report.xlsx'."
 }
-$outputDir = Split-Path -LiteralPath $OutputPath -Parent
-# New-Item has no -LiteralPath parameter (only -Path/-Name), so we
-# cannot use the same -LiteralPath idiom we use on the surrounding
-# Test-Path/Split-Path/Remove-Item calls. Drop to the underlying
-# .NET API which takes a literal path string by definition: no
-# wildcard interpretation, no PSDrive resolution quirks, identical
-# behaviour on Windows, macOS, and Linux. The call is idempotent
-# (creates the directory if missing, no-op if it already exists),
-# so the surrounding Test-Path check is technically redundant but
-# kept for readability and to mirror the file-existence check on
-# the next line.
+# Path-manipulation primitives here drop to .NET because the
+# obvious PowerShell idioms have parameter-set traps:
+#   - Split-Path -LiteralPath ... -Parent is invalid because
+#     -LiteralPath and -Parent live in different parameter sets
+#     (LiteralPathSet vs ParentSet) and PowerShell cannot resolve
+#     the call. [System.IO.Path]::GetDirectoryName() is the literal-
+#     string equivalent.
+#   - New-Item has no -LiteralPath parameter at all (only -Path /
+#     -Name), so it would either need [WildcardPattern]::Escape on
+#     the input or a drop to .NET. [System.IO.Directory]::
+#     CreateDirectory() is idempotent (no-op if the directory
+#     already exists), takes a literal path by definition, and
+#     behaves identically on Windows, macOS, and Linux.
+# The surrounding Test-Path / Remove-Item calls keep -LiteralPath
+# because those cmdlets do support it; this block is therefore
+# consistent on "literal path, no wildcard interpretation" without
+# pretending every cmdlet supports the same parameter name.
+$outputDir = [System.IO.Path]::GetDirectoryName($OutputPath)
 if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { [void][System.IO.Directory]::CreateDirectory($outputDir) }
 if (Test-Path -LiteralPath $OutputPath) { Remove-Item -LiteralPath $OutputPath -Force }
 

--- a/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -920,7 +920,17 @@ if (-not $IsWindows -and $OutputPath -match '^[A-Za-z]:[\\/]') {
     throw "OutputPath '$OutputPath' uses a Windows drive path, which is not valid on macOS/Linux. Use a forward-slash path instead, e.g. '/tmp/report.xlsx' or './report.xlsx'."
 }
 $outputDir = Split-Path -LiteralPath $OutputPath -Parent
-if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -LiteralPath $outputDir -Force | Out-Null }
+# New-Item has no -LiteralPath parameter (only -Path/-Name), so we
+# cannot use the same -LiteralPath idiom we use on the surrounding
+# Test-Path/Split-Path/Remove-Item calls. Drop to the underlying
+# .NET API which takes a literal path string by definition: no
+# wildcard interpretation, no PSDrive resolution quirks, identical
+# behaviour on Windows, macOS, and Linux. The call is idempotent
+# (creates the directory if missing, no-op if it already exists),
+# so the surrounding Test-Path check is technically redundant but
+# kept for readability and to mirror the file-existence check on
+# the next line.
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { [void][System.IO.Directory]::CreateDirectory($outputDir) }
 if (Test-Path -LiteralPath $OutputPath) { Remove-Item -LiteralPath $OutputPath -Force }
 
 Write-Host ""


### PR DESCRIPTION
## Summary
Follow-up to [#23](https://github.com/noodlemctwoodle/Sentinel-As-Code/pull/23). That PR merged with two runtime regressions introduced by auto-applied Copilot review-suggestion fixes. Every invocation of `Export-SdlMigrationWorkbook.ps1` that reaches the output-directory-resolution step (i.e. every successful run) now fails with:

```
Parameter set cannot be resolved using the specified named parameters.
One or more parameters issued cannot be used together or an insufficient
number of parameters were provided.
```

Two distinct bugs, same shape:

1. **`New-Item -LiteralPath`** — `New-Item` does not have a `-LiteralPath` parameter at all. Only `-Path` and `-Name`. The auto-applied suggestion added a parameter that doesn't exist on the cmdlet.
2. **`Split-Path -LiteralPath $OutputPath -Parent`** — both parameters exist on `Split-Path`, but in *different parameter sets* (`LiteralPathSet` vs `ParentSet`) which can't be combined. Verified by enumerating the parameter sets directly:

   ```
   ParentSet         HasLiteralPath=False HasParent=True
   LiteralPathSet    HasLiteralPath=True  HasParent=False
   ```

The original intent (make the directory-resolution block literal-path-safe so paths containing `[`, `]`, `*`, `?` on macOS/Linux are handled correctly) is preserved, but both PowerShell calls are replaced with their .NET equivalents which take literal strings by definition:

- `Split-Path -Parent` → `[System.IO.Path]::GetDirectoryName($OutputPath)`
- `New-Item -ItemType Directory -Force` → `[void][System.IO.Directory]::CreateDirectory($outputDir)`

The surrounding `Test-Path -LiteralPath` and `Remove-Item -LiteralPath` calls keep their PowerShell form because those cmdlets do support `-LiteralPath`. A multi-line comment above the block documents the parameter-set traps so this doesn't drift back to the PowerShell idiom in a future refactor.

## Test plan
- [ ] `git pull && ./Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1 -SubscriptionId <sub> -ResourceGroupName <rg> -WorkspaceName <ws>` — confirm the xlsx is now written (script previously failed at the directory-creation step on every invocation).
- [ ] Run with `-OutputPath "/tmp/sdl-test [bracket]/foo.xlsx"` on macOS and confirm the bracketed parent directory is created correctly with no wildcard misbehaviour from `GetDirectoryName` or `CreateDirectory`.
- [ ] Run with `-OutputPath "/tmp/report [v2].xlsx"` on macOS and confirm filenames containing wildcard chars also work.
- [ ] Run on Windows with `-OutputPath "C:\Reports\foo.xlsx"` and confirm Windows behaviour is unchanged.

## Cross-platform verification
Verified end-to-end on macOS PS7 with the full post-guard block:
- Bracketed parent dir: `/tmp/.../Projects [Archive]/report.xlsx` → directory created literally, no wildcard interpretation.
- Wildcard chars in filename: `report [v2].xlsx` → handled cleanly.
- Relative path: `./local-test.xlsx` → `outputDir` resolves to `.` (correct).
- Plain absolute path: `/tmp/.../report.xlsx` → standard behaviour preserved.
- Pre-existing target file: `Remove-Item -LiteralPath` fires correctly.
- Drive-path guard upstream still throws on `C:\...` before this block runs on non-Windows.

## Commit history
- `9bdff64` — replace broken `New-Item -LiteralPath` with `[System.IO.Directory]::CreateDirectory`.
- `b36d6c9` — replace broken `Split-Path -LiteralPath -Parent` with `[System.IO.Path]::GetDirectoryName`; unified rationale comment covering both .NET drops.