### PR TITLE
fix(documenter): correct include-preview expression quoting in sentinel-document workflow

### DIFF
--- a/.github/workflows/sentinel-document.yml
+++ b/.github/workflows/sentinel-document.yml
@@ -145,7 +145,7 @@ jobs:
             $ErrorActionPreference = 'Stop'
             $env:SENTINEL_RG          = '${{ vars.SENTINEL_RG }}'
             $env:SENTINEL_WORKSPACE   = '${{ vars.SENTINEL_WORKSPACE }}'
-            $includePreview = [bool]::Parse('${{ inputs.include-preview || ''false'' }}')
+            $includePreview = [bool]::Parse('${{ inputs.include-preview || 'false' }}')
 
             ./Scripts/Documenter/Export-SentinelInventory.ps1 `
               -SubscriptionId  '${{ secrets.AZURE_SUBSCRIPTION_ID }}' `


### PR DESCRIPTION
## What

One-line fix to `.github/workflows/sentinel-document.yml`.

The collector step's inline expression used doubled single-quotes:

```
$includePreview = [bool]::Parse('${{ inputs.include-preview || ''false'' }}')
```

GitHub Actions cannot parse `''false''` ("Unexpected symbol: 'false'"), so the **whole workflow failed to compile**. Every scheduled run and manual dispatch errored in 0s before any step executed. This reached `main` via the Wave 4 squash-merge (#25), so the Sentinel Documenter action is currently failing on `main`.

## Fix

Use a single-quoted expression string literal:

```
$includePreview = [bool]::Parse('${{ inputs.include-preview || 'false' }}')
```

Block scalars do not apply YAML single-quote escaping, so the doubled quotes were wrong.

## Testing

- Workflow YAML parses locally.
- No other doubled-quote expressions remain in the workflow.