### PR TITLE
feat(content): add Copilot activity monitoring content pack

### DIFF
--- a/Content/AnalyticalRules/CloudAppEvents/CopilotMassSensitiveResourceAccessDetectionRule.yaml
+++ b/Content/AnalyticalRules/CloudAppEvents/CopilotMassSensitiveResourceAccessDetectionRule.yaml
@@ -1,0 +1,59 @@
+id: 4df245b7-a2cc-4263-839f-76ec26728a57
+name: Copilot mass access to sensitivity-labelled resources
+description: |
+  Detects an account whose Copilot interactions referenced a high number of
+  distinct sensitivity-labelled resources within a single hour. Copilot
+  surfacing many labelled items in a short window can indicate deliberate data
+  harvesting through natural-language prompts, or a compromised account being
+  used to stage sensitive content for exfiltration.
+
+  Combines two investigation questions: did Copilot access sensitive
+  resources, and is the volume normal for this user?
+
+  An analyst should review the referenced resources and labels, confirm the
+  activity is expected for the user's role, and check for follow-on download,
+  share or mail-forwarding activity.
+
+  Verify in tenant: the RawEventData path to CopilotEventData.AccessedResources
+  and the ActionType value. Tune the threshold to the environment.
+severity: Medium
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+queryFrequency: PT1H
+queryPeriod: PT1H
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- Collection
+relevantTechniques:
+- T1213
+- T1530
+query: |
+  CloudAppEvents
+  | where TimeGenerated > ago(1h)
+  | where ActionType == "CopilotInteraction"
+  | mv-expand Resource = RawEventData.CopilotEventData.AccessedResources
+  | extend SensitivityLabelId = tostring(Resource.SensitivityLabelId)
+  | where isnotempty(SensitivityLabelId)
+  | summarize
+      LabelledResourceCount = dcount(tostring(Resource.Id)),
+      Labels = make_set(SensitivityLabelId, 20),
+      ResourceNames = make_set(tostring(Resource.Name), 20),
+      IPs = make_set(IPAddress, 10)
+    by AccountObjectId, AccountDisplayName
+  | where LabelledResourceCount > 15
+  | order by LabelledResourceCount desc
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: AadUserId
+    columnName: AccountObjectId
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/CloudAppEvents/HighImpactUserAnomalousCopilotAccessDetectionRule.yaml
+++ b/Content/AnalyticalRules/CloudAppEvents/HighImpactUserAnomalousCopilotAccessDetectionRule.yaml
@@ -1,0 +1,94 @@
+id: 603ac5ba-ba08-40f6-8d0d-5162766164f2
+name: High-impact user anomalous Copilot access
+description: |
+  Detects Microsoft 365 Copilot activity by a privileged or high-impact
+  account from a country that has not been seen for that account in the
+  previous 14 days. High-impact accounts are resolved from IdentityInfo by
+  directory role and privileged group membership, so a new-country Copilot
+  session for one of these identities is treated as a priority signal for
+  credential theft or session hijack.
+
+  Combines two investigation questions: is the source country normal for this
+  user, and is the user high impact?
+
+  An analyst should confirm whether the user is travelling, review the source
+  IP against threat intelligence, and check for correlated risky sign-ins or
+  OAuth consent grants on the same account.
+
+  The CloudAppEvents ActionType for Copilot is "CopilotInteraction".
+severity: High
+requiredDataConnectors:
+- connectorId: MicrosoftThreatProtection
+  dataTypes:
+  - CloudAppEvents
+- connectorId: BehaviorAnalytics
+  dataTypes:
+  - IdentityInfo
+queryFrequency: P1D
+queryPeriod: P14D
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- InitialAccess
+- Collection
+relevantTechniques:
+- T1078
+- T1078.004
+query: |
+  let Privileged = IdentityInfo
+    | where TimeGenerated > ago(14d)
+    | where AssignedRoles has_any (
+        "Global Administrator", "Security Administrator",
+        "Privileged Role Administrator", "Exchange Administrator",
+        "SharePoint Administrator", "User Administrator",
+        "Application Administrator", "Cloud Application Administrator",
+        "Hybrid Identity Administrator")
+        or GroupMembership has_any (
+        "Domain Admins", "Enterprise Admins",
+        "Azure AD Joined Device Local Administrators")
+    | summarize arg_max(TimeGenerated, *) by AccountObjectId
+    | project AccountObjectId, AccountUPN, AssignedRoles, Department, JobTitle;
+  let Baseline = CloudAppEvents
+    | where TimeGenerated between (ago(14d) .. ago(1d))
+    | where ActionType == "CopilotInteraction"
+    | summarize by AccountObjectId, CountryCode;
+  CloudAppEvents
+  | where TimeGenerated > ago(1d)
+  | where ActionType == "CopilotInteraction"
+  | project TimeGenerated, AccountObjectId, IPAddress, CountryCode, City, ISP, UserAgent, DeviceType, Application
+  | join kind=inner Privileged on AccountObjectId
+  | join kind=leftanti Baseline on AccountObjectId, CountryCode
+  | where isnotempty(CountryCode)
+  | project
+      TimeGenerated,
+      AccountObjectId,
+      AccountUPN,
+      AssignedRoles,
+      Department,
+      JobTitle,
+      IPAddress,
+      CountryCode,
+      City,
+      ISP,
+      UserAgent,
+      DeviceType,
+      Application
+  | order by TimeGenerated desc
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: Name
+    columnName: AccountUPN
+  - identifier: AadUserId
+    columnName: AccountObjectId
+- entityType: IP
+  fieldMappings:
+  - identifier: Address
+    columnName: IPAddress
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/CopilotActivity/CopilotJailbreakDetectedDetectionRule.yaml
+++ b/Content/AnalyticalRules/CopilotActivity/CopilotJailbreakDetectedDetectionRule.yaml
@@ -1,0 +1,60 @@
+id: bf96f3f4-aa2b-46d9-a17e-9561726e9024
+name: Copilot jailbreak attempt detected (CopilotActivity)
+description: |
+  Alerts when Microsoft Copilot flags a message as a jailbreak attempt in the
+  CopilotActivity table (LLMEventData.Messages[].JailbreakDetected == true).
+  A jailbreak attempt is a deliberate effort to bypass Copilot safety controls
+  to extract data or coerce unintended behaviour, and warrants review of the
+  account and the prompts involved.
+
+  An analyst should review the flagged messages, confirm whether the activity
+  is a security test or genuine abuse, check whether the same account accessed
+  sensitive resources through Copilot, and correlate with sign-in risk.
+severity: High
+requiredDataConnectors:
+- connectorId: MicrosoftCopilot
+  dataTypes:
+  - CopilotActivity
+queryFrequency: PT1H
+queryPeriod: PT1H
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- DefenseEvasion
+relevantTechniques:
+- T1562
+query: |
+  CopilotActivity
+  | where TimeGenerated > ago(1h)
+  | where RecordType == "CopilotInteraction"
+  | extend Messages = LLMEventData.Messages
+  | mv-expand Messages
+  | where tobool(Messages.JailbreakDetected) == true
+  | project
+      TimeGenerated,
+      ActorName,
+      ActorUserId,
+      SrcIpAddr,
+      ClientRegion,
+      AppHost,
+      AgentName,
+      MessageId = tostring(Messages.Id)
+  | order by TimeGenerated desc
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: Name
+    columnName: ActorName
+  - identifier: AadUserId
+    columnName: ActorUserId
+- entityType: IP
+  fieldMappings:
+  - identifier: Address
+    columnName: SrcIpAddr
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/CopilotActivity/HighImpactUserCopilotActivityFromNewRegionDetectionRule.yaml
+++ b/Content/AnalyticalRules/CopilotActivity/HighImpactUserCopilotActivityFromNewRegionDetectionRule.yaml
@@ -1,0 +1,90 @@
+id: 2380ceef-4f42-4679-b9e3-d316c05a06f9
+name: High-impact user Copilot activity from a new region (CopilotActivity)
+description: |
+  Detects Copilot activity in the CopilotActivity table by a privileged or
+  high-impact account from a client region that has not been seen for that
+  account in the previous 14 days. High-impact accounts are resolved from
+  IdentityInfo by directory role and privileged group membership, so a
+  new-region Copilot session for one of these identities is a priority signal
+  for credential theft or session hijack.
+
+  Combines two investigation questions: is the source region normal for this
+  user, and is the user high impact?
+
+  An analyst should confirm whether the user is travelling, review the source
+  IP against threat intelligence, and check for correlated risky sign-ins or
+  OAuth consent grants on the same account.
+severity: High
+requiredDataConnectors:
+- connectorId: MicrosoftCopilot
+  dataTypes:
+  - CopilotActivity
+- connectorId: BehaviorAnalytics
+  dataTypes:
+  - IdentityInfo
+queryFrequency: P1D
+queryPeriod: P14D
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- InitialAccess
+- Collection
+relevantTechniques:
+- T1078
+- T1078.004
+query: |
+  let Privileged = IdentityInfo
+    | where TimeGenerated > ago(14d)
+    | where AssignedRoles has_any (
+        "Global Administrator", "Security Administrator",
+        "Privileged Role Administrator", "Exchange Administrator",
+        "SharePoint Administrator", "User Administrator",
+        "Application Administrator", "Cloud Application Administrator",
+        "Hybrid Identity Administrator")
+        or GroupMembership has_any (
+        "Domain Admins", "Enterprise Admins",
+        "Azure AD Joined Device Local Administrators")
+    | summarize arg_max(TimeGenerated, *) by AccountObjectId
+    | project AccountUpn = tolower(AccountUpn), AssignedRoles, Department, JobTitle;
+  let Baseline = CopilotActivity
+    | where TimeGenerated between (ago(14d) .. ago(1d))
+    | where RecordType == "CopilotInteraction"
+    | summarize by ActorUserId, ClientRegion;
+  CopilotActivity
+  | where TimeGenerated > ago(1d)
+  | where RecordType == "CopilotInteraction"
+  | project TimeGenerated, ActorName, ActorUserId, SrcIpAddr, ClientRegion, AppHost, AppIdentity
+  | join kind=leftanti Baseline on ActorUserId, ClientRegion
+  | where isnotempty(ClientRegion)
+  | extend AccountUpn = tolower(ActorName)
+  | join kind=inner Privileged on AccountUpn
+  | project
+      TimeGenerated,
+      ActorName,
+      ActorUserId,
+      AssignedRoles,
+      Department,
+      JobTitle,
+      SrcIpAddr,
+      ClientRegion,
+      AppHost,
+      AppIdentity
+  | order by TimeGenerated desc
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: Name
+    columnName: ActorName
+  - identifier: AadUserId
+    columnName: ActorUserId
+- entityType: IP
+  fieldMappings:
+  - identifier: Address
+    columnName: SrcIpAddr
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/CopilotActivity/UnentitledUserCopilotActivityDetectionRule.yaml
+++ b/Content/AnalyticalRules/CopilotActivity/UnentitledUserCopilotActivityDetectionRule.yaml
@@ -1,7 +1,7 @@
 id: 15badc16-22eb-4028-960f-360feab01f58
 name: Copilot usage by an unentitled user (CopilotActivity)
 description: |
-  'Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
+  Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
   generates Copilot activity in the CopilotActivity table in the last day. This
   catches Copilot access granted outside the normal entitlement process and
   Copilot use by accounts that should not have it, including potentially
@@ -10,7 +10,7 @@ description: |
   Investigation question answered: is this user expected to use Copilot?
 
   REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
-  Until the watchlist exists the deployer will disable the rule automatically.'
+  Until the watchlist exists the deployer will disable the rule automatically.
 severity: Medium
 requiredDataConnectors:
 - connectorId: MicrosoftCopilot

--- a/Content/AnalyticalRules/CopilotActivity/UnentitledUserCopilotActivityDetectionRule.yaml
+++ b/Content/AnalyticalRules/CopilotActivity/UnentitledUserCopilotActivityDetectionRule.yaml
@@ -1,0 +1,57 @@
+id: 15badc16-22eb-4028-960f-360feab01f58
+name: Copilot usage by an unentitled user (CopilotActivity)
+description: |
+  'Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
+  generates Copilot activity in the CopilotActivity table in the last day. This
+  catches Copilot access granted outside the normal entitlement process and
+  Copilot use by accounts that should not have it, including potentially
+  compromised identities.
+
+  Investigation question answered: is this user expected to use Copilot?
+
+  REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
+  Until the watchlist exists the deployer will disable the rule automatically.'
+severity: Medium
+requiredDataConnectors:
+- connectorId: MicrosoftCopilot
+  dataTypes:
+  - CopilotActivity
+queryFrequency: P1D
+queryPeriod: P1D
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- InitialAccess
+relevantTechniques:
+- T1078
+- T1078.004
+query: |
+  let EntitledUsers = _GetWatchlist('CopilotEntitledUsers')
+    | project UserPrincipalName = tolower(UserPrincipalName);
+  CopilotActivity
+  | where TimeGenerated > ago(1d)
+  | where RecordType == "CopilotInteraction"
+  | extend UserPrincipalName = tolower(ActorName)
+  | where UserPrincipalName !in (EntitledUsers)
+  | summarize
+      Interactions = count(),
+      Surfaces = make_set(AppHost, 10),
+      SourceIPs = make_set(SrcIpAddr, 20),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by UserPrincipalName, ActorUserId
+  | where Interactions > 0
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: Name
+    columnName: UserPrincipalName
+  - identifier: AadUserId
+    columnName: ActorUserId
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/OfficeActivity/UnentitledUserCopilotUsageDetectionRule.yaml
+++ b/Content/AnalyticalRules/OfficeActivity/UnentitledUserCopilotUsageDetectionRule.yaml
@@ -1,0 +1,55 @@
+id: 09cded01-b045-4811-b2ec-92de27db16f3
+name: Copilot usage by an unentitled user
+description: |
+  'Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
+  generates Microsoft 365 Copilot activity in the last day. This catches
+  Copilot access granted outside the normal entitlement process and Copilot
+  use by accounts that should not have it, including potentially compromised
+  identities.
+
+  Investigation question answered: is this user expected to use Copilot?
+
+  REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
+  Until the watchlist exists the deployer will disable the rule automatically.
+  Verify in tenant: OfficeActivity carries the CopilotInteraction operation.'
+severity: Medium
+requiredDataConnectors:
+- connectorId: Office365
+  dataTypes:
+  - OfficeActivity
+queryFrequency: P1D
+queryPeriod: P1D
+triggerOperator: gt
+triggerThreshold: 0
+enabled: true
+tactics:
+- InitialAccess
+relevantTechniques:
+- T1078
+- T1078.004
+query: |
+  let EntitledUsers = _GetWatchlist('CopilotEntitledUsers')
+    | project UserPrincipalName = tolower(UserPrincipalName);
+  OfficeActivity
+  | where TimeGenerated > ago(1d)
+  | where Operation == "CopilotInteraction"
+  | extend UserPrincipalName = tolower(UserId)
+  | where UserPrincipalName !in (EntitledUsers)
+  | summarize
+      Interactions = count(),
+      ClientIPs = make_set(ClientIP, 20),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by UserPrincipalName
+  | where Interactions > 0
+entityMappings:
+- entityType: Account
+  fieldMappings:
+  - identifier: Name
+    columnName: UserPrincipalName
+version: 1.0.0
+kind: Scheduled
+tags:
+- Sentinel-As-Code
+- Custom
+- Copilot

--- a/Content/AnalyticalRules/OfficeActivity/UnentitledUserCopilotUsageDetectionRule.yaml
+++ b/Content/AnalyticalRules/OfficeActivity/UnentitledUserCopilotUsageDetectionRule.yaml
@@ -1,7 +1,7 @@
 id: 09cded01-b045-4811-b2ec-92de27db16f3
 name: Copilot usage by an unentitled user
 description: |
-  'Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
+  Alerts when an account that is not on the "CopilotEntitledUsers" watchlist
   generates Microsoft 365 Copilot activity in the last day. This catches
   Copilot access granted outside the normal entitlement process and Copilot
   use by accounts that should not have it, including potentially compromised
@@ -11,7 +11,7 @@ description: |
 
   REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
   Until the watchlist exists the deployer will disable the rule automatically.
-  Verify in tenant: OfficeActivity carries the CopilotInteraction operation.'
+  Verify in tenant: OfficeActivity carries the CopilotInteraction operation.
 severity: Medium
 requiredDataConnectors:
 - connectorId: Office365

--- a/Content/DefenderCustomDetections/CloudAppEvents/AnomalousCopilotSessionForPrivilegedIdentity.yaml
+++ b/Content/DefenderCustomDetections/CloudAppEvents/AnomalousCopilotSessionForPrivilegedIdentity.yaml
@@ -1,0 +1,51 @@
+displayName: Anomalous Copilot session for a privileged identity
+isEnabled: true
+queryCondition:
+  queryText: |
+    let PrivilegedUsers =
+        IdentityInfo
+        | where Timestamp > ago(10d)
+        | where AssignedRoles has_any (
+            "Global Administrator", "Security Administrator",
+            "Privileged Role Administrator", "Exchange Administrator",
+            "SharePoint Administrator", "User Administrator",
+            "Application Administrator", "Cloud Application Administrator")
+        | distinct AccountObjectId;
+    let Baseline =
+        CloudAppEvents
+        | where Timestamp between (ago(31d) .. ago(1h))
+        | where ActionType == "CopilotInteraction"
+        | summarize by AccountObjectId, CountryCode;
+    CloudAppEvents
+    | where Timestamp > ago(1h)
+    | where ActionType == "CopilotInteraction"
+    | where AccountObjectId in (PrivilegedUsers)
+    | project Timestamp, ReportId, AccountObjectId, AccountDisplayName,
+              IPAddress, CountryCode, City, ISP, UserAgent, DeviceType, Application
+    | join kind=leftanti Baseline on AccountObjectId, CountryCode
+    | where isnotempty(CountryCode)
+  lastModifiedDateTime: "2026-07-07T00:00:00Z"
+schedule:
+  period: "1H"
+detectionAction:
+  alertTemplate:
+    title: "Anomalous Copilot session for a privileged identity"
+    description: |
+      A privileged account used Copilot from a country that has not been seen
+      for that account in the previous 30 days. Privileged identities are
+      high-value targets, so a new-country Copilot session may indicate stolen
+      credentials or a hijacked session being used to explore tenant data.
+    severity: high
+    category: InitialAccess
+    mitreTechniques:
+      - T1078.004
+    recommendedActions: |
+      1. Confirm whether the account owner is travelling or using a VPN.
+      2. Review the source IP and ISP against threat intelligence.
+      3. Check the same account for risky sign-ins and OAuth consent grants.
+      4. Review what Copilot referenced during the session for sensitive data.
+      5. If unauthorised, disable the account, revoke sessions and reset credentials.
+    impactedAssets:
+      - "@odata.type": "#microsoft.graph.security.impactedUserAsset"
+        identifier: accountObjectId
+  responseActions: []

--- a/Content/DefenderCustomDetections/CloudAppEvents/AnomalousCopilotSessionForPrivilegedIdentity.yaml
+++ b/Content/DefenderCustomDetections/CloudAppEvents/AnomalousCopilotSessionForPrivilegedIdentity.yaml
@@ -24,7 +24,7 @@ queryCondition:
               IPAddress, CountryCode, City, ISP, UserAgent, DeviceType, Application
     | join kind=leftanti Baseline on AccountObjectId, CountryCode
     | where isnotempty(CountryCode)
-  lastModifiedDateTime: "2026-07-07T00:00:00Z"
+lastModifiedDateTime: "2026-07-07T00:00:00Z"
 schedule:
   period: "1H"
 detectionAction:

--- a/Content/HuntingQueries/CloudAppEvents/CopilotAnomalousSourceContext.yaml
+++ b/Content/HuntingQueries/CloudAppEvents/CopilotAnomalousSourceContext.yaml
@@ -1,0 +1,40 @@
+id: c7292339-6762-4aa1-8ceb-ec2c86ee16dc
+name: Copilot activity from anomalous source context
+description: |
+  Flags Copilot activity where the combination of country, ISP and user agent
+  has not been seen for that account in the prior 30 days. New source context
+  for an account that otherwise has an established Copilot footprint can
+  indicate session theft, token replay from an attacker host, or use from an
+  unmanaged device.
+
+  Investigation question answered: is the source IP, ISP, country, device or
+  user agent normal for this user?
+
+  The CloudAppEvents ActionType for Copilot is "CopilotInteraction"; verify the
+  enrichment column names (ISP, UserAgent) in tenant.
+query: |
+  let Baseline = CloudAppEvents
+    | where TimeGenerated between (ago(31d) .. ago(1d))
+    | where ActionType == "CopilotInteraction"
+    | summarize by AccountObjectId, CountryCode, ISP, UserAgent;
+  CloudAppEvents
+  | where TimeGenerated > ago(1d)
+  | where ActionType == "CopilotInteraction"
+  | project
+      TimeGenerated,
+      AccountObjectId,
+      AccountDisplayName,
+      IPAddress,
+      CountryCode,
+      City,
+      ISP,
+      UserAgent,
+      DeviceType,
+      Application
+  | join kind=leftanti Baseline on AccountObjectId, CountryCode, ISP, UserAgent
+  | order by TimeGenerated desc
+tactics:
+  - InitialAccess
+techniques:
+  - T1078
+  - T1078.004

--- a/Content/HuntingQueries/CloudAppEvents/CopilotAnomalousSourceContext.yaml
+++ b/Content/HuntingQueries/CloudAppEvents/CopilotAnomalousSourceContext.yaml
@@ -16,10 +16,12 @@ query: |
   let Baseline = CloudAppEvents
     | where TimeGenerated between (ago(31d) .. ago(1d))
     | where ActionType == "CopilotInteraction"
+    | extend ISP = column_ifexists('ISP', ''), UserAgent = column_ifexists('UserAgent', '')
     | summarize by AccountObjectId, CountryCode, ISP, UserAgent;
   CloudAppEvents
   | where TimeGenerated > ago(1d)
   | where ActionType == "CopilotInteraction"
+  | extend ISP = column_ifexists('ISP', ''), UserAgent = column_ifexists('UserAgent', '')
   | project
       TimeGenerated,
       AccountObjectId,

--- a/Content/HuntingQueries/CloudAppEvents/CopilotInteractionVolumeSpike.yaml
+++ b/Content/HuntingQueries/CloudAppEvents/CopilotInteractionVolumeSpike.yaml
@@ -1,0 +1,54 @@
+id: 2450e68c-f551-4f7e-adb1-93c4f3abba4b
+name: Copilot interaction volume spike versus user baseline
+description: |
+  Compares each user's Copilot interaction count today against their own
+  14-day baseline and flags accounts exceeding the mean plus three standard
+  deviations. A sudden spike can indicate automated or scripted use, bulk
+  data collection through Copilot, or an attacker exercising a compromised
+  identity.
+
+  Investigation question answered: is the volume normal for this user?
+
+  The CloudAppEvents ActionType for Copilot is "CopilotInteraction". Confirm in
+  tenant with
+  `CloudAppEvents | where RawEventData has "Copilot" | distinct ActionType`.
+query: |
+  let Lookback = 14d;
+  // Materialise the Copilot slice once and project only the needed columns:
+  // the slice is consumed by both branches below, so this avoids scanning
+  // CloudAppEvents twice and stops the large RawEventData blob being carried.
+  let Copilot = materialize(
+      CloudAppEvents
+      | where TimeGenerated > ago(Lookback)
+      | where ActionType == "CopilotInteraction"
+      | project TimeGenerated, AccountObjectId, AccountDisplayName, IPAddress, Application);
+  let Baseline = Copilot
+    | where TimeGenerated < startofday(now())
+    | summarize DailyCount = count() by AccountObjectId, Day = startofday(TimeGenerated)
+    | summarize AvgPerDay = avg(DailyCount), StdevPerDay = stdev(DailyCount) by AccountObjectId;
+  let Today = Copilot
+    | where TimeGenerated >= startofday(now())
+    | summarize
+        TodayCount = count(),
+        IPs = make_set(IPAddress, 20),
+        Surfaces = make_set(Application, 10)
+      by AccountObjectId, AccountDisplayName;
+  Today
+  | join kind=leftouter Baseline on AccountObjectId
+  | extend AvgPerDay = coalesce(AvgPerDay, 0.0), StdevPerDay = coalesce(StdevPerDay, 0.0)
+  | extend Threshold = AvgPerDay + (3 * StdevPerDay)
+  | where TodayCount > 20 and TodayCount > Threshold
+  | project
+      AccountObjectId,
+      AccountDisplayName,
+      TodayCount,
+      AvgPerDay = round(AvgPerDay, 1),
+      Threshold = round(Threshold, 1),
+      Surfaces,
+      IPs
+  | order by TodayCount desc
+tactics:
+  - Collection
+techniques:
+  - T1213
+  - T1530

--- a/Content/HuntingQueries/CloudAppEvents/CopilotSensitiveResourceAccess.yaml
+++ b/Content/HuntingQueries/CloudAppEvents/CopilotSensitiveResourceAccess.yaml
@@ -1,0 +1,35 @@
+id: bf721b59-df8a-4c29-bead-c0025c020e40
+name: Copilot referenced sensitivity-labelled resources
+description: |
+  Expands the resources that Copilot referenced when answering a prompt and
+  keeps only those carrying a sensitivity label. This shows which labelled
+  files, sites and items were surfaced to a user through Copilot, which is a
+  key signal when investigating potential oversharing or data collection.
+
+  Investigation question answered: did Copilot access sensitive resources?
+
+  Verify in tenant: the RawEventData path to CopilotEventData.AccessedResources
+  and the ActionType value. The Microsoft 365 audit record exposes the same
+  data via OfficeActivity if CloudAppEvents is not available.
+query: |
+  CloudAppEvents
+  | where TimeGenerated > ago(1d)
+  | where ActionType == "CopilotInteraction"
+  | mv-expand Resource = RawEventData.CopilotEventData.AccessedResources
+  | extend SensitivityLabelId = tostring(Resource.SensitivityLabelId)
+  | where isnotempty(SensitivityLabelId)
+  | project
+      TimeGenerated,
+      AccountObjectId,
+      AccountDisplayName,
+      IPAddress,
+      ResourceName = tostring(Resource.Name),
+      SiteUrl = tostring(Resource.SiteUrl),
+      SensitivityLabelId,
+      ResourceAction = tostring(Resource.Action)
+  | order by TimeGenerated desc
+tactics:
+  - Collection
+techniques:
+  - T1213
+  - T1530

--- a/Content/HuntingQueries/CloudAppEvents/SecurityCopilotInteractionOverview.yaml
+++ b/Content/HuntingQueries/CloudAppEvents/SecurityCopilotInteractionOverview.yaml
@@ -1,0 +1,35 @@
+id: 67d058ab-13c7-46cc-9931-88265c59c9c5
+name: Security Copilot interaction overview
+description: |
+  Summarises Microsoft Security Copilot usage per account across both the
+  embedded experiences (Defender, Purview, Intune) and the standalone portal.
+  Because Security Copilot operates over security data, unexpected users or
+  unusual source locations warrant review.
+
+  Investigation questions supported: who is using Security Copilot, how much,
+  and from where.
+
+  Verify in tenant: the AppIdentity value (Copilot.Security.SecurityCopilot),
+  the RawEventData path, and the ActionType value used for Copilot activity.
+query: |
+  CloudAppEvents
+  | where TimeGenerated > ago(7d)
+  | where ActionType == "CopilotInteraction"
+  | extend
+      AppIdentity = tostring(RawEventData.AppIdentity),
+      AppHost = tostring(RawEventData.CopilotEventData.AppHost)
+  | where AppIdentity == "Copilot.Security.SecurityCopilot"
+      or AppHost in ("Defender", "Purview", "Intune", "Security Copilot Standalone")
+  | summarize
+      Interactions = count(),
+      Hosts = make_set(AppHost, 10),
+      Countries = make_set(CountryCode, 20),
+      IPs = make_set(IPAddress, 30),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by AccountObjectId, AccountDisplayName
+  | order by Interactions desc
+tactics:
+  - Discovery
+techniques:
+  - T1526

--- a/Content/HuntingQueries/CopilotActivity/CopilotActivityFromNewLocation.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotActivityFromNewLocation.yaml
@@ -1,0 +1,28 @@
+id: 421d5182-3528-4ee3-9169-278b80c915d1
+name: Copilot activity from a new source location (CopilotActivity)
+description: |
+  Flags Copilot interactions where the combination of source IP and client
+  region has not been seen for that account in the prior 30 days. The
+  CopilotActivity table exposes SrcIpAddr and ClientRegion directly, so this
+  catches Copilot use from a new network location which can indicate session
+  theft or token replay from an attacker host.
+
+  Investigation question answered: is the source IP or region normal for this
+  user? (CopilotActivity does not carry ISP or user agent; correlate with
+  SigninLogs for those dimensions.)
+query: |
+  let Baseline = CopilotActivity
+    | where TimeGenerated between (ago(31d) .. ago(1d))
+    | where RecordType == "CopilotInteraction"
+    | summarize by ActorUserId, SrcIpAddr, ClientRegion;
+  CopilotActivity
+  | where TimeGenerated > ago(1d)
+  | where RecordType == "CopilotInteraction"
+  | project TimeGenerated, ActorName, ActorUserId, SrcIpAddr, ClientRegion, AppHost, AppIdentity
+  | join kind=leftanti Baseline on ActorUserId, SrcIpAddr, ClientRegion
+  | order by TimeGenerated desc
+tactics:
+  - InitialAccess
+techniques:
+  - T1078
+  - T1078.004

--- a/Content/HuntingQueries/CopilotActivity/CopilotActivitySensitiveResourceAccess.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotActivitySensitiveResourceAccess.yaml
@@ -1,0 +1,34 @@
+id: ce931ab0-bae7-457d-aaf2-70d883f909d1
+name: Copilot referenced sensitivity-labelled resources (CopilotActivity)
+description: |
+  Expands the resources Copilot referenced when answering a prompt, from the
+  LLMEventData.AccessedResources array in the CopilotActivity table, and keeps
+  only those carrying a sensitivity label. This shows which labelled files and
+  sites were surfaced to a user through Copilot, a key signal when investigating
+  oversharing or data collection.
+
+  Investigation question answered: did Copilot access sensitive resources?
+query: |
+  CopilotActivity
+  | where TimeGenerated > ago(1d)
+  | where RecordType == "CopilotInteraction"
+  | extend AccessedResources = LLMEventData.AccessedResources
+  | mv-expand Resource = AccessedResources
+  | extend SensitivityLabelId = tostring(Resource.SensitivityLabelId)
+  | where isnotempty(SensitivityLabelId)
+  | project
+      TimeGenerated,
+      ActorName,
+      ActorUserId,
+      SrcIpAddr,
+      ResourceName = tostring(Resource.Name),
+      SiteUrl = tostring(Resource.SiteUrl),
+      SensitivityLabelId,
+      ResourceAction = tostring(Resource.Action),
+      ResourceType = tostring(Resource.Type)
+  | order by TimeGenerated desc
+tactics:
+  - Collection
+techniques:
+  - T1213
+  - T1530

--- a/Content/HuntingQueries/CopilotActivity/CopilotActivityUsageByUnentitledUser.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotActivityUsageByUnentitledUser.yaml
@@ -1,0 +1,33 @@
+id: 1417a02d-05dd-491e-aacd-0f28c08e793b
+name: Copilot activity by an unentitled user (CopilotActivity)
+description: |
+  Surfaces Microsoft Copilot interactions recorded in the CopilotActivity
+  table for accounts that are not on the "CopilotEntitledUsers" watchlist.
+  CopilotActivity is the dedicated Microsoft Copilot data-connector table, so
+  this is the highest-fidelity view of who is using Copilot without a recorded
+  entitlement.
+
+  Investigation question answered: is this user expected to use Copilot?
+
+  REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
+query: |
+  let EntitledUsers = _GetWatchlist('CopilotEntitledUsers')
+    | project UserPrincipalName = tolower(UserPrincipalName);
+  CopilotActivity
+  | where TimeGenerated > ago(7d)
+  | where RecordType == "CopilotInteraction"
+  | extend UserPrincipalName = tolower(ActorName)
+  | where UserPrincipalName !in (EntitledUsers)
+  | summarize
+      Interactions = count(),
+      Surfaces = make_set(AppHost, 10),
+      SourceIPs = make_set(SrcIpAddr, 20),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by UserPrincipalName, ActorUserId
+  | order by Interactions desc
+tactics:
+  - InitialAccess
+techniques:
+  - T1078
+  - T1078.004

--- a/Content/HuntingQueries/CopilotActivity/CopilotActivityVolumeSpike.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotActivityVolumeSpike.yaml
@@ -1,0 +1,49 @@
+id: 3e82884b-06b1-450c-9a87-90907b0d0d37
+name: Copilot interaction volume spike versus user baseline (CopilotActivity)
+description: |
+  Compares each user's Copilot interaction count today against their own
+  14-day baseline in the CopilotActivity table and flags accounts exceeding
+  the mean plus three standard deviations. A sudden spike can indicate
+  automated or scripted use, bulk data collection through Copilot, or a
+  compromised identity.
+
+  Investigation question answered: is the volume normal for this user?
+query: |
+  let Lookback = 14d;
+  // Materialise the interaction slice once; it is consumed by both branches.
+  let Copilot = materialize(
+      CopilotActivity
+      | where TimeGenerated > ago(Lookback)
+      | where RecordType == "CopilotInteraction"
+      | project TimeGenerated, ActorName, ActorUserId, SrcIpAddr, AppHost);
+  let Baseline = Copilot
+    | where TimeGenerated < startofday(now())
+    | summarize DailyCount = count() by ActorUserId, Day = startofday(TimeGenerated)
+    | summarize AvgPerDay = avg(DailyCount), StdevPerDay = stdev(DailyCount) by ActorUserId;
+  let Today = Copilot
+    | where TimeGenerated >= startofday(now())
+    | summarize
+        TodayCount = count(),
+        ActorName = any(ActorName),
+        SourceIPs = make_set(SrcIpAddr, 20),
+        Surfaces = make_set(AppHost, 10)
+      by ActorUserId;
+  Today
+  | join kind=leftouter Baseline on ActorUserId
+  | extend AvgPerDay = coalesce(AvgPerDay, 0.0), StdevPerDay = coalesce(StdevPerDay, 0.0)
+  | extend Threshold = AvgPerDay + (3 * StdevPerDay)
+  | where TodayCount > 20 and TodayCount > Threshold
+  | project
+      ActorName,
+      ActorUserId,
+      TodayCount,
+      AvgPerDay = round(AvgPerDay, 1),
+      Threshold = round(Threshold, 1),
+      Surfaces,
+      SourceIPs
+  | order by TodayCount desc
+tactics:
+  - Collection
+techniques:
+  - T1213
+  - T1530

--- a/Content/HuntingQueries/CopilotActivity/CopilotJailbreakAttempts.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotJailbreakAttempts.yaml
@@ -1,0 +1,40 @@
+id: acf89a4b-94ee-4177-8cf9-1e5fbdc7a310
+name: Copilot jailbreak or prompt-injection attempts (CopilotActivity)
+description: |
+  Surfaces Copilot interactions where the platform flagged a message as a
+  jailbreak attempt (LLMEventData.Messages[].JailbreakDetected == true in the
+  CopilotActivity table). Repeated jailbreak attempts by an account indicate a
+  user, or a compromised identity, trying to bypass Copilot guardrails to
+  extract data or coerce unintended behaviour.
+
+  Investigation focus: which accounts are probing Copilot safety controls, from
+  where, and against which surfaces or agents.
+query: |
+  CopilotActivity
+  | where TimeGenerated > ago(7d)
+  | where RecordType == "CopilotInteraction"
+  | extend Messages = LLMEventData.Messages
+  | mv-expand Messages
+  | where tobool(Messages.JailbreakDetected) == true
+  | project
+      TimeGenerated,
+      ActorName,
+      ActorUserId,
+      SrcIpAddr,
+      ClientRegion,
+      AppHost,
+      AgentName,
+      MessageId = tostring(Messages.Id)
+  | summarize
+      JailbreakAttempts = count(),
+      Surfaces = make_set(AppHost, 10),
+      Agents = make_set(AgentName, 10),
+      SourceIPs = make_set(SrcIpAddr, 20),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by ActorName, ActorUserId
+  | order by JailbreakAttempts desc
+tactics:
+  - DefenseEvasion
+techniques:
+  - T1562

--- a/Content/HuntingQueries/CopilotActivity/CopilotPluginAndPromptBookManagement.yaml
+++ b/Content/HuntingQueries/CopilotActivity/CopilotPluginAndPromptBookManagement.yaml
@@ -1,0 +1,33 @@
+id: fd07ce13-2d58-4a50-a6b3-ca14b226716f
+name: Copilot plugin, PromptBook and settings changes (CopilotActivity)
+description: |
+  Surfaces Copilot governance events in the CopilotActivity table: plugin
+  creation, updates and enable/disable, PromptBook creation, updates and
+  deletion, and Copilot settings changes. New plugins and PromptBooks change
+  what Copilot can reach and how it behaves, so these authoring events are a
+  governance blind spot worth reviewing against expected ownership.
+
+  Investigation focus: who is changing Copilot plugins, PromptBooks and
+  settings, and from where.
+query: |
+  CopilotActivity
+  | where TimeGenerated > ago(7d)
+  | where RecordType in (
+      "CreateCopilotPlugin", "UpdateCopilotPlugin",
+      "EnableCopilotPlugin", "DisableCopilotPlugin",
+      "CreateCopilotPromptBook", "UpdateCopilotPromptBook", "DeleteCopilotPromptBook",
+      "UpdateCopilotSettings")
+  | project
+      TimeGenerated,
+      RecordType,
+      ActorName,
+      ActorUserId,
+      AgentName,
+      AppHost,
+      SrcIpAddr,
+      ClientRegion
+  | order by TimeGenerated desc
+tactics:
+  - Persistence
+techniques:
+  - T1098

--- a/Content/HuntingQueries/CopilotActivity/SecurityCopilotActivityOverview.yaml
+++ b/Content/HuntingQueries/CopilotActivity/SecurityCopilotActivityOverview.yaml
@@ -1,0 +1,31 @@
+id: ab7862b5-5cc7-481b-a135-e9f165f6985f
+name: Security Copilot activity overview (CopilotActivity)
+description: |
+  Summarises Microsoft Security Copilot usage per account from the
+  CopilotActivity table, identified by the AppIdentity and AppHost of the
+  interaction. Because Security Copilot operates over security data,
+  unexpected users or unusual source locations warrant review.
+
+  Investigation focus: who is using Security Copilot, how much, and from where.
+
+  Verify in tenant: the AppIdentity value (Copilot.Security.SecurityCopilot)
+  and the AppHost values for the embedded and standalone experiences.
+query: |
+  CopilotActivity
+  | where TimeGenerated > ago(7d)
+  | where RecordType == "CopilotInteraction"
+  | where AppIdentity == "Copilot.Security.SecurityCopilot"
+      or AppHost in ("Defender", "Purview", "Intune", "Security Copilot Standalone")
+  | summarize
+      Interactions = count(),
+      Hosts = make_set(AppHost, 10),
+      Regions = make_set(ClientRegion, 20),
+      SourceIPs = make_set(SrcIpAddr, 30),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by ActorName, ActorUserId
+  | order by Interactions desc
+tactics:
+  - Discovery
+techniques:
+  - T1526

--- a/Content/HuntingQueries/OfficeActivity/CopilotStudioAgentGovernanceChanges.yaml
+++ b/Content/HuntingQueries/OfficeActivity/CopilotStudioAgentGovernanceChanges.yaml
@@ -1,0 +1,35 @@
+id: 9a5b7452-784f-40d1-929a-0c3372c611a0
+name: Copilot Studio agent lifecycle and sharing changes
+description: |
+  Surfaces Copilot Studio authoring and governance events: agent creation and
+  deletion, publish, authentication changes, sharing, component changes and
+  plugin operations. Newly created or newly shared agents are a governance
+  blind spot because they can expose data connectors and actions to a wider
+  audience than intended.
+
+  Investigation question supported: establishes who is standing up and sharing
+  agents so their activity can be weighed against expected ownership.
+
+  Verify in tenant: these operations arrive through the Office 365 / Purview
+  audit connector; the agent-specific columns are read defensively.
+query: |
+  OfficeActivity
+  | where TimeGenerated > ago(7d)
+  | where Operation in~ (
+      "BotCreate", "BotDelete", "BotDeleteCleanup",
+      "BotUpdateOperation-BotNameUpdate", "BotUpdateOperation-BotAuthUpdate",
+      "BotUpdateOperation-BotPublish", "BotUpdateOperation-BotShare",
+      "BotComponentCreate", "BotComponentUpdate", "BotComponentDelete",
+      "AIPluginOperationCreate", "AIPluginOperationUpdate", "AIPluginOperationDelete")
+  | project
+      TimeGenerated,
+      Operation,
+      UserId,
+      ClientIP,
+      BotId = column_ifexists("BotId", ""),
+      BotSchemaName = column_ifexists("BotSchemaName", "")
+  | order by TimeGenerated desc
+tactics:
+  - Persistence
+techniques:
+  - T1098

--- a/Content/HuntingQueries/OfficeActivity/CopilotUsageByUnentitledUser.yaml
+++ b/Content/HuntingQueries/OfficeActivity/CopilotUsageByUnentitledUser.yaml
@@ -1,0 +1,34 @@
+id: 7b94bb12-9047-4a2c-9578-ada9130a7292
+name: Copilot usage by a user without entitlement
+description: |
+  Surfaces Microsoft 365 Copilot interactions performed by accounts that are
+  not on the "CopilotEntitledUsers" watchlist. An account generating Copilot
+  activity without a recorded entitlement can indicate a licensing gap, an
+  account that has been granted access outside the normal process, or a
+  compromised identity exercising Copilot for reconnaissance.
+
+  Investigation question answered: is this user expected to use Copilot?
+
+  REQUIRES WATCHLIST = "CopilotEntitledUsers" with a "UserPrincipalName" column.
+  Verify in tenant: OfficeActivity carries the CopilotInteraction operation for
+  Microsoft 365 Copilot; adjust if your estate routes it differently.
+query: |
+  let EntitledUsers = _GetWatchlist('CopilotEntitledUsers')
+    | project UserPrincipalName = tolower(UserPrincipalName);
+  OfficeActivity
+  | where TimeGenerated > ago(7d)
+  | where Operation == "CopilotInteraction"
+  | extend UserPrincipalName = tolower(UserId)
+  | where UserPrincipalName !in (EntitledUsers)
+  | summarize
+      Interactions = count(),
+      ClientIPs = make_set(ClientIP, 20),
+      FirstSeen = min(TimeGenerated),
+      LastSeen = max(TimeGenerated)
+    by UserPrincipalName
+  | order by Interactions desc
+tactics:
+  - InitialAccess
+techniques:
+  - T1078
+  - T1078.004

--- a/Content/HuntingQueries/OfficeActivity/CopilotUserWithCorrelatedRisk.yaml
+++ b/Content/HuntingQueries/OfficeActivity/CopilotUserWithCorrelatedRisk.yaml
@@ -1,0 +1,51 @@
+id: cc833d84-d024-4496-ad4d-d59072382b6b
+name: Copilot user with correlated risk signals
+description: |
+  Joins accounts that used Copilot in the last day against three independent
+  risk signals in the same window: a risky sign-in, an OAuth application
+  consent grant, and a Microsoft Defender alert. An account that is both
+  active in Copilot and lit up by another control deserves priority triage.
+
+  Investigation question answered: did the same account also show suspicious
+  sign-in, OAuth, mailbox, SharePoint, Teams or Defender activity?
+
+  Verify in tenant: OfficeActivity carries the CopilotInteraction operation;
+  SecurityAlert entity parsing assumes the standard account entity shape.
+query: |
+  let Window = 1d;
+  let CopilotUsers = OfficeActivity
+    | where TimeGenerated > ago(Window)
+    | where Operation == "CopilotInteraction"
+    | summarize CopilotInteractions = count() by UserPrincipalName = tolower(UserId);
+  let RiskySignins = SigninLogs
+    | where TimeGenerated > ago(Window)
+    | where RiskLevelDuringSignIn in ("high", "medium")
+    | summarize Value = count() by UserPrincipalName = tolower(UserPrincipalName)
+    | extend Signal = "RiskySignin";
+  let OAuthConsents = AuditLogs
+    | where TimeGenerated > ago(Window)
+    | where OperationName has "Consent to application"
+    | summarize Value = count() by UserPrincipalName = tolower(tostring(InitiatedBy.user.userPrincipalName))
+    | extend Signal = "OAuthConsent";
+  let DefenderAlerts = SecurityAlert
+    | where TimeGenerated > ago(Window)
+    | mv-expand Entity = todynamic(Entities)
+    | where tostring(Entity.Type) == "account"
+    | extend UserPrincipalName = tolower(strcat(tostring(Entity.Name), "@", tostring(Entity.UPNSuffix)))
+    | where UserPrincipalName != "@"
+    | summarize Value = dcount(SystemAlertId) by UserPrincipalName
+    | extend Signal = "DefenderAlert";
+  let RiskSignals = union RiskySignins, OAuthConsents, DefenderAlerts;
+  CopilotUsers
+  | join kind=inner RiskSignals on UserPrincipalName
+  | summarize
+      CopilotInteractions = any(CopilotInteractions),
+      RiskSignals = make_bag(pack(Signal, Value))
+    by UserPrincipalName
+  | order by UserPrincipalName asc
+tactics:
+  - InitialAccess
+  - CredentialAccess
+techniques:
+  - T1078
+  - T1528

--- a/Content/Watchlists/CopilotEntitledUsers/data.csv
+++ b/Content/Watchlists/CopilotEntitledUsers/data.csv
@@ -1,0 +1,2 @@
+UserPrincipalName,DisplayName,Reason,DateAdded,AddedBy
+seed@example.onmicrosoft.com,Example Entitled User,Seed entry,2026-07-07,SOC

--- a/Content/Watchlists/CopilotEntitledUsers/watchlist.json
+++ b/Content/Watchlists/CopilotEntitledUsers/watchlist.json
@@ -1,0 +1,7 @@
+{
+  "watchlistAlias": "CopilotEntitledUsers",
+  "displayName": "Copilot Entitled Users",
+  "description": "Users expected to have Microsoft 365 Copilot entitlement. Detection rules use this list to flag Copilot activity by accounts that are not entitled. Populate with the UPNs of licensed or approved Copilot users.",
+  "provider": "Custom",
+  "itemsSearchKey": "UserPrincipalName"
+}

--- a/dependencies.json
+++ b/dependencies.json
@@ -50,6 +50,17 @@
         "https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/MSFTIPRanges/ServiceTags_Public.json"
       ]
     },
+    "Content/AnalyticalRules/CloudAppEvents/CopilotMassSensitiveResourceAccessDetectionRule.yaml": {
+      "tables": [
+        "CloudAppEvents"
+      ]
+    },
+    "Content/AnalyticalRules/CloudAppEvents/HighImpactUserAnomalousCopilotAccessDetectionRule.yaml": {
+      "tables": [
+        "CloudAppEvents",
+        "IdentityInfo"
+      ]
+    },
     "Content/AnalyticalRules/Community/Dalonso/AzureActivity/AzureAutomationRunbookCreatedOrPublishedByFirstTimeCaller.yaml": {
       "tables": [
         "AzureActivity"
@@ -637,6 +648,25 @@
         "SigninLogs"
       ]
     },
+    "Content/AnalyticalRules/CopilotActivity/CopilotJailbreakDetectedDetectionRule.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/AnalyticalRules/CopilotActivity/HighImpactUserCopilotActivityFromNewRegionDetectionRule.yaml": {
+      "tables": [
+        "CopilotActivity",
+        "IdentityInfo"
+      ]
+    },
+    "Content/AnalyticalRules/CopilotActivity/UnentitledUserCopilotActivityDetectionRule.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ],
+      "watchlists": [
+        "CopilotEntitledUsers"
+      ]
+    },
     "Content/AnalyticalRules/Custom/ChangeWasMadeToTailscale.yaml": {
       "tables": [
         "TailscaleAudit_CL"
@@ -969,6 +999,14 @@
         "MicrosoftGraphActivityLogs"
       ]
     },
+    "Content/AnalyticalRules/OfficeActivity/UnentitledUserCopilotUsageDetectionRule.yaml": {
+      "tables": [
+        "OfficeActivity"
+      ],
+      "watchlists": [
+        "CopilotEntitledUsers"
+      ]
+    },
     "Content/AnalyticalRules/PrivilegeEscalation/UserAddedToPrivilegedGroupDetectionRule.yaml": {
       "tables": [
         "AuditLogs"
@@ -1057,6 +1095,64 @@
     "Content/HuntingQueries/AzureActivity/AzureResourceChangesRiskDetection1kSample.yaml": {
       "tables": [
         "AzureActivity"
+      ]
+    },
+    "Content/HuntingQueries/CloudAppEvents/CopilotAnomalousSourceContext.yaml": {
+      "tables": [
+        "CloudAppEvents"
+      ]
+    },
+    "Content/HuntingQueries/CloudAppEvents/CopilotInteractionVolumeSpike.yaml": {
+      "tables": [
+        "CloudAppEvents"
+      ]
+    },
+    "Content/HuntingQueries/CloudAppEvents/CopilotSensitiveResourceAccess.yaml": {
+      "tables": [
+        "CloudAppEvents"
+      ]
+    },
+    "Content/HuntingQueries/CloudAppEvents/SecurityCopilotInteractionOverview.yaml": {
+      "tables": [
+        "CloudAppEvents"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotActivityFromNewLocation.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotActivitySensitiveResourceAccess.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotActivityUsageByUnentitledUser.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ],
+      "watchlists": [
+        "CopilotEntitledUsers"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotActivityVolumeSpike.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotJailbreakAttempts.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/CopilotPluginAndPromptBookManagement.yaml": {
+      "tables": [
+        "CopilotActivity"
+      ]
+    },
+    "Content/HuntingQueries/CopilotActivity/SecurityCopilotActivityOverview.yaml": {
+      "tables": [
+        "CopilotActivity"
       ]
     },
     "Content/HuntingQueries/DeviceProcessEvents/MaliciousPowershellPatternAnalysis.yaml": {
@@ -1152,6 +1248,27 @@
         "AuditLogs",
         "IdentityInfo",
         "MicrosoftGraphActivityLogs"
+      ]
+    },
+    "Content/HuntingQueries/OfficeActivity/CopilotStudioAgentGovernanceChanges.yaml": {
+      "tables": [
+        "OfficeActivity"
+      ]
+    },
+    "Content/HuntingQueries/OfficeActivity/CopilotUsageByUnentitledUser.yaml": {
+      "tables": [
+        "OfficeActivity"
+      ],
+      "watchlists": [
+        "CopilotEntitledUsers"
+      ]
+    },
+    "Content/HuntingQueries/OfficeActivity/CopilotUserWithCorrelatedRisk.yaml": {
+      "tables": [
+        "AuditLogs",
+        "OfficeActivity",
+        "SecurityAlert",
+        "SigninLogs"
       ]
     },
     "Content/HuntingQueries/Persistence/AzureVmRunCommandExecution.yaml": {


### PR DESCRIPTION
## Summary

Adds a Copilot activity monitoring content pack: detection and hunting content for Microsoft 365 Copilot and Security Copilot usage across the `CloudAppEvents`, `CopilotActivity`, and `OfficeActivity` tables.

## What is included

- **Analytical rules (6)** - new-region privileged activity, jailbreak detection, unentitled usage, mass sensitive-resource access, high-impact anomalous access.
- **Defender custom detection (1)** - anomalous Copilot session for a privileged identity.
- **Hunting queries (14)** - source-context anomalies, interaction volume spikes, sensitive-resource access, jailbreak attempts, plugin/prompt-book management, unentitled usage, correlated user risk, Copilot Studio agent governance changes.
- **Watchlist (1)** - `CopilotEntitledUsers` (watchlist.json + data.csv) backing the unentitled-usage detections.
- **dependencies.json** regenerated via `Tools/Build-DependencyManifest.ps1 -Mode Generate` (260 entries; +117 for the new content).

## Testing

- `./Tools/Invoke-PRValidation.ps1` - all Pester suites pass (6688 assertions, 0 failures).
- Dependency manifest regeneration is idempotent (no drift on a second run).

## Notes

- Branch cut from `main`, so the diff is only this content pack.
- Deliberately excludes the unrelated `Docs/Development/Placeholder_...Build-and-Test-Guide.docx` that was in the working tree.

