### PR TITLE
feat(ci): add PR template validation gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ What the automated check enforces:
 
 Convention notes (per .github/copilot-instructions.md and AGENTS.md):
   - en-GB spelling (analyse, behaviour, customise, prioritise)
-  - No em-dashes (-) in new prose; hyphens or parenthetical phrasing instead
+  - No em-dashes (—) in new prose; hyphens (-) or parenthetical phrasing instead
   - No AI / LLM references in commit messages or PR descriptions
   - No Co-Authored-By trailers for AI tools
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,20 @@
 <!--
-Thanks for contributing to Sentinel-As-Code. Fill the sections below.
-Empty sections / unchecked boxes are fine — replace placeholder text
-with your own. Remove sections that don't apply.
+Thanks for contributing to Sentinel-As-Code. This template is checked
+automatically by the "PR Template Validation" status check. Sections
+marked (required) MUST contain real content or the check fails and the
+PR cannot merge. Replace the guidance in each comment with your own
+words; do not delete the required headings. Optional sections can be
+removed if they do not apply.
+
+What the automated check enforces:
+  - Summary, Why, What does this change do?, and Testing each hold a
+    real description (not just the placeholder comment).
+  - At least one "Type of change" box is ticked with [x].
+  - The required headings are still present.
 
 Convention notes (per .github/copilot-instructions.md and AGENTS.md):
   - en-GB spelling (analyse, behaviour, customise, prioritise)
-  - No em-dashes (—) in new prose; hyphens or parenthetical phrasing instead
+  - No em-dashes (-) in new prose; hyphens or parenthetical phrasing instead
   - No AI / LLM references in commit messages or PR descriptions
   - No Co-Authored-By trailers for AI tools
 -->
@@ -13,37 +22,64 @@ Convention notes (per .github/copilot-instructions.md and AGENTS.md):
 ## Summary
 
 <!--
-One or two paragraphs. What does this PR do, and why?
+(required) One or two sentences: what does this PR deliver, in plain
+terms? Keep it short - the detail goes in the sections below.
+-->
 
-If it adds new content (rule, hunting query, watchlist, playbook,
-etc.), name the threat scenario / use case. If it changes pipeline
-behaviour, mention which platforms (GitHub / ADO / both).
+## Why is this change needed?
+
+<!--
+(required) The motivation. What problem, gap, risk, or request drove
+this change? What was wrong, missing, or painful before it?
+
+For new detection content, name the threat scenario / use case and why
+it matters. For a pipeline change, say what was failing or fragile.
+Link the issue / incident / request if there is one.
+-->
+
+## What does this change do?
+
+<!--
+(required) Describe the change itself. What did you actually add or
+alter, and how does it work? Mention the approach or design decision
+if it is not obvious from the diff.
+
+For content, name the table(s) / data source the query drives off. For
+pipeline changes, say which platforms are touched (GitHub / ADO / both).
+-->
+
+## What does this fix or affect?
+
+<!--
+Optional. Bugs fixed, issues closed (use "Fixes #123"), behaviour that
+changes, and anything downstream that is impacted. Call out breaking
+changes loudly. Write "No behavioural change" if that is the case.
 -->
 
 ## Type of change
 
-<!-- Check all that apply -->
+<!-- (required) Tick at least one box with [x]. -->
 
-- [ ] feat — new capability
-- [ ] fix — bug fix
-- [ ] refactor — restructure without behavioural change
-- [ ] perf — measurable performance improvement
-- [ ] docs — documentation only
-- [ ] test — Pester / schema test changes
-- [ ] chore — dependency bump, version pin, file rename
-- [ ] ci — workflow / pipeline change
-- [ ] tune — analytical-rule threshold / severity / filter change
+- [ ] feat - new capability
+- [ ] fix - bug fix
+- [ ] refactor - restructure without behavioural change
+- [ ] perf - measurable performance improvement
+- [ ] docs - documentation only
+- [ ] test - Pester / schema test changes
+- [ ] chore - dependency bump, version pin, file rename
+- [ ] ci - workflow / pipeline change
+- [ ] tune - analytical-rule threshold / severity / filter change
 
 ## Files changed (high level)
 
 <!--
-Bullet list of the meaningful changes, grouped logically.
+Optional. Bullet list of the meaningful changes, grouped logically.
 Don't paste a `git diff --stat`; describe intent.
 
 Example:
-- AnalyticalRules/AzureActivity/<Name>.yaml — new rule for <scenario>
-- dependencies.json — regenerated to include the new rule
-- Tests/Test-X.Tests.ps1 — added one assertion for <case>
+- AnalyticalRules/AzureActivity/<Name>.yaml - new rule for <scenario>
+- dependencies.json - regenerated to include the new rule
+- Tests/Test-X.Tests.ps1 - added one assertion for <case>
 -->
 
 ## Pre-merge checklist
@@ -65,7 +101,7 @@ them when you've confirmed locally so reviewers know what was run.
 ## Testing
 
 <!--
-What did you do to confirm the change works?
+(required) What did you do to confirm the change works?
 
 For schema changes: which Pester suite did you run?
 For pipeline changes: did you `workflow_dispatch` smoke test before
@@ -77,16 +113,17 @@ workspace? Which one?
 ## Required PR-validation status checks
 
 <!--
-The Main Branch Protection ruleset requires these five checks. They
-run automatically when you open the PR. None should be skipped without
+The Main Branch Protection ruleset requires these checks. They run
+automatically when you open the PR. None should be skipped without
 explicit reviewer agreement.
 -->
 
-- `validate` — Pester suite under Tests/
-- `bicep-build` — `az bicep build` against Infra/**/*.bicep
-- `arm-validate` — Test-AzResourceGroupDeployment -WhatIf for playbooks (OIDC)
-- `kql-validate` — Microsoft.Azure.Kusto.Language parser across all queries
-- `dependency-manifest` — dependencies.json drift gate
+- `template` - PR description matches the template (this file)
+- `validate` - Pester suite under Tests/
+- `bicep-build` - `az bicep build` against Infra/**/*.bicep
+- `arm-validate` - Test-AzResourceGroupDeployment -WhatIf for playbooks (OIDC)
+- `kql-validate` - Microsoft.Azure.Kusto.Language parser across all queries
+- `dependency-manifest` - dependencies.json drift gate
 
 ## Related
 

--- a/.github/agents/test-engineer.agent.md
+++ b/.github/agents/test-engineer.agent.md
@@ -146,7 +146,7 @@ The repo's tricky cases:
 | `Sentinel.Common` exports | Every public function has unit tests |
 | Critical scripts (deploy, drift, dep-manifest) | Higher bar — every branch in core orchestration |
 
-Existing total: ~6,000 assertions across 17 files. Run-time
+Existing total: ~6,000 assertions across 18 files. Run-time
 under 30s on a clean clone.
 
 ## Hand-offs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,7 +152,7 @@ Conventional commit format: `type(scope): brief description`.
 
 ## Testing
 
-Every PR runs the full Pester suite (~6,000 assertions across 17
+Every PR runs the full Pester suite (~6,000 assertions across 18
 files) plus the schema gates. To run locally before pushing:
 
 ```powershell

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -22,6 +22,7 @@ Reference doc:
 | `.github/workflows/sentinel-dcr-inventory.yml` | `Pipelines/Sentinel-DCR-Inventory.yml` | On change: deploy DCR inventory runbook |
 | `.github/workflows/sentinel-dependency-update.yml` | `Pipelines/Sentinel-Dependency-Update.yml` | Daily 02:00 UTC: refresh `dependencies.json` + auto-PR |
 | `.github/workflows/pr-validation.yml` | `Pipelines/Sentinel-PR-Validation.yml` | On every PR: 5-job merge gate |
+| `.github/workflows/pr-template-validation.yml` | *(GitHub-only)* | On every PR: fail if the PR description does not fill in `.github/PULL_REQUEST_TEMPLATE.md` |
 | `.github/workflows/sentinel-deploy-nightly.yml` | *(GitHub-only)* | Daily 03:00 UTC: E2E smoke test against test workspace |
 
 ## Composite actions

--- a/.github/workflows/pr-template-validation.yml
+++ b/.github/workflows/pr-template-validation.yml
@@ -1,0 +1,97 @@
+# ---------------------------------------------------------------------------
+# GitHub Actions Workflow: PR Template Validation
+# ---------------------------------------------------------------------------
+# Fails a pull request when its description does not follow
+# .github/PULL_REQUEST_TEMPLATE.md - i.e. when the author left a required
+# section empty (Summary / Why is this change needed? / What does this
+# change do? / Testing) or ticked no "Type of change" box. Reviewers rely
+# on that context, so an empty or copy-paste body should not merge.
+#
+# The check re-runs on the 'edited' event, so a contributor can fix the
+# description in the GitHub UI and watch the check go green without pushing
+# a new commit.
+#
+# The parsing / rules live in Tools/Test-PullRequestTemplate.ps1 (unit
+# tested by Tests/Test-PullRequestTemplate.Tests.ps1). This workflow only
+# hands the PR body to that script.
+#
+# Platform note (GitHub-only, platform-forced divergence per
+# .github/instructions/workflows.instructions.md Hard rule 1): the PR body
+# arrives in the Actions event payload. The Azure DevOps equivalent would
+# have to fetch the PR description over the REST API from a build-validation
+# policy, a fundamentally different shape, so there is intentionally no
+# Pipelines/ mirror of this workflow.
+#
+# Wiring as a required merge gate (one-off, after it has run once):
+#
+#   Repo Settings -> Rules -> Rulesets -> Main Branch Protection -> Edit
+#     Require status checks to pass -> Add checks:
+#       - template
+#
+# Bot-authored PRs (the drift-sync and dependency-manifest auto-PRs, head
+# branch 'auto/*') do not use the human template, so the job short-circuits
+# to success for them rather than blocking their auto-merge flow.
+# ---------------------------------------------------------------------------
+
+name: PR Template Validation
+
+on:
+  pull_request:
+    branches: [main]
+    # 'edited' is what makes a description fix re-trigger the check without a
+    # new commit. 'synchronize' keeps the check present on each new head sha
+    # so a required-check ruleset always has a result to gate on.
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+# Cancel any in-flight run for the same PR when a new event arrives; keeps
+# the latest status check fresh and saves CI minutes.
+concurrency:
+  group: pr-template-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  template:
+    name: template
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      # Short-circuit for bot / auto-sync PRs. Done as a step (not a job-level
+      # 'if') so the job still reports success and a required-check ruleset is
+      # not left waiting for a status that never arrives.
+      - name: Skip bot and auto-sync PRs
+        id: skip
+        env:
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          HEAD_REF:       ${{ github.head_ref }}
+        run: |
+          should_skip=false
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
+              should_skip=true
+          fi
+          case "$HEAD_REF" in
+              auto/*) should_skip=true ;;
+          esac
+          echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
+          if [ "$should_skip" = "true" ]; then
+              echo "::notice::Bot or auto-sync PR ('$HEAD_REF') - PR template validation skipped."
+          fi
+
+      - name: Checkout PR branch
+        if: steps.skip.outputs.should_skip != 'true'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      # The PR body is untrusted input. It is passed through an environment
+      # variable and never interpolated into the command line, so a body
+      # containing shell metacharacters cannot inject anything.
+      - name: Validate PR description against the template
+        if: steps.skip.outputs.should_skip != 'true'
+        shell: pwsh
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ./Tools/Test-PullRequestTemplate.ps1 -Body $env:PR_BODY

--- a/.github/workflows/pr-template-validation.yml
+++ b/.github/workflows/pr-template-validation.yml
@@ -28,9 +28,12 @@
 #     Require status checks to pass -> Add checks:
 #       - template
 #
-# Bot-authored PRs (the drift-sync and dependency-manifest auto-PRs, head
-# branch 'auto/*') do not use the human template, so the job short-circuits
-# to success for them rather than blocking their auto-merge flow.
+# Bot-authored PRs (the drift-sync and dependency-manifest auto-PRs are opened
+# with GITHUB_TOKEN, so their author is github-actions[bot], type "Bot") do not
+# use the human template, so the job short-circuits to success for them rather
+# than blocking their auto-merge flow. The head branch name is deliberately NOT
+# trusted as a skip condition - a human could name a branch 'auto/foo' to dodge
+# this required check.
 # ---------------------------------------------------------------------------
 
 name: PR Template Validation
@@ -61,23 +64,20 @@ jobs:
       # Short-circuit for bot / auto-sync PRs. Done as a step (not a job-level
       # 'if') so the job still reports success and a required-check ruleset is
       # not left waiting for a status that never arrives.
-      - name: Skip bot and auto-sync PRs
+      - name: Skip bot-authored PRs
         id: skip
         env:
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
-          HEAD_REF:       ${{ github.head_ref }}
         run: |
+          # Skip only genuinely bot-authored PRs. The branch name is NOT a
+          # trusted skip condition: a human could name a branch 'auto/foo' to
+          # bypass this required check.
           should_skip=false
           if [ "$PR_AUTHOR_TYPE" = "Bot" ]; then
               should_skip=true
+              echo "::notice::Bot-authored PR (author type '$PR_AUTHOR_TYPE') - PR template validation skipped."
           fi
-          case "$HEAD_REF" in
-              auto/*) should_skip=true ;;
-          esac
           echo "should_skip=$should_skip" >> "$GITHUB_OUTPUT"
-          if [ "$should_skip" = "true" ]; then
-              echo "::notice::Bot or auto-sync PR ('$HEAD_REF') - PR template validation skipped."
-          fi
 
       # Check out the BASE ref (trusted), not the PR head, so the validator
       # script always runs from main. Otherwise a PR could neuter its own gate

--- a/.github/workflows/pr-template-validation.yml
+++ b/.github/workflows/pr-template-validation.yml
@@ -79,10 +79,14 @@ jobs:
               echo "::notice::Bot or auto-sync PR ('$HEAD_REF') - PR template validation skipped."
           fi
 
-      - name: Checkout PR branch
+      # Check out the BASE ref (trusted), not the PR head, so the validator
+      # script always runs from main. Otherwise a PR could neuter its own gate
+      # by editing Tools/Test-PullRequestTemplate.ps1 in the same change.
+      - name: Checkout base ref (trusted validator)
         if: steps.skip.outputs.should_skip != 'true'
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
 
       # The PR body is untrusted input. It is passed through an environment
@@ -94,4 +98,10 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
+          # Bootstrap guard: on the PR that first introduces the validator the
+          # base ref does not have it yet, so there is nothing trusted to run.
+          if (-not (Test-Path ./Tools/Test-PullRequestTemplate.ps1)) {
+              Write-Host "::notice::Validator not present on the base ref yet (bootstrap PR); skipping."
+              exit 0
+          }
           ./Tools/Test-PullRequestTemplate.ps1 -Body $env:PR_BODY

--- a/Docs/Deploy/Pipelines.md
+++ b/Docs/Deploy/Pipelines.md
@@ -13,12 +13,17 @@ deployment, and operational tooling.
 
 > **GitHub Actions equivalents** of every pipeline live under
 > [`.github/workflows/`](../../.github/workflows/). They share the same
-> schedules and behaviour. Plus two GitHub-only workflows that have no
+> schedules and behaviour. Plus three GitHub-only workflows that have no
 > ADO equivalent:
 >
 > - [`pr-validation.yml`](../../.github/workflows/pr-validation.yml) —
 >   five-job merge gate (validate, bicep-build, arm-validate,
 >   kql-validate, dependency-manifest)
+> - [`pr-template-validation.yml`](../../.github/workflows/pr-template-validation.yml) —
+>   fails a PR whose description does not fill in
+>   [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+>   (the `template` status check). GitHub-only: the PR body arrives in the
+>   Actions event payload, which has no ADO build-validation equivalent.
 > - [`sentinel-deploy-nightly.yml`](../../.github/workflows/sentinel-deploy-nightly.yml) —
 >   nightly E2E smoke test against the test workspace, daily 03:00 UTC
 

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -14,6 +14,7 @@ one-time bootstrap and ad-hoc maintenance tooling.
 | `Build-DependencyManifest.ps1` | Auto-derives `dependencies.json` from KQL discovery (Generate / Verify / Update modes) | [#build-dependencymanifestps1](#build-dependencymanifestps1) |
 | `Export-SentinelWorkbooks.ps1` | Exports every Sentinel workbook in a workspace into the `Content/Workbooks/` folder shape that `Deploy-CustomWorkbooks` reads back | [#export-sentinelworkbooksps1](#export-sentinelworkbooksps1) |
 | `Invoke-PRValidation.ps1` | Cross-platform PR-validation entrypoint — runs every Pester suite under `Tests/` and emits a JUnit XML report | See [Pester Tests](../Development/Pester-Tests.md) |
+| `Test-PullRequestTemplate.ps1` | Validates a PR description against `.github/PULL_REQUEST_TEMPLATE.md`; drives the PR Template Validation workflow | See [Pipelines](Pipelines.md) |
 | `Test-SentinelRuleDrift.ps1` | Detects portal-edited rules and absorbs Custom drift | See [Sentinel Drift Detection](../Tools/Sentinel-Drift-Detection.md) |
 
 ## Setup-ServicePrincipal.ps1

--- a/Docs/Development/Pester-Tests.md
+++ b/Docs/Development/Pester-Tests.md
@@ -131,6 +131,7 @@ ruleset can require independently:
 | Workbooks | [`Tests/Test-WorkbookJson.Tests.ps1`](../../Tests/Test-WorkbookJson.Tests.ps1) | ARM-vs-gallery format detection; cross-directory GUID uniqueness for ARM workbooks |
 | Playbooks (structural) | [`Tests/Test-PlaybookArm.Tests.ps1`](../../Tests/Test-PlaybookArm.Tests.ps1) | ARM template structure + workflow trigger/action presence |
 | Helper module self-test | [`Tests/Test-ImportScriptFunctions.Tests.ps1`](../../Tests/Test-ImportScriptFunctions.Tests.ps1) | AST extractor synthetic + real-repo round-trip |
+| PR template validator | [`Tests/Test-PullRequestTemplate.Tests.ps1`](../../Tests/Test-PullRequestTemplate.Tests.ps1) | `Remove-MarkdownComment`, `Get-PullRequestSection`, `Test-PullRequestTemplateBody` (required-section + tick-box rules for the PR description) |
 | Sentinel.Common module | [`Tests/Test-SentinelCommon.Tests.ps1`](../../Tests/Test-SentinelCommon.Tests.ps1) | `Write-PipelineMessage` ADO/local branching · `Invoke-SentinelApi` failure handling · `Connect-AzureEnvironment` state-shape contract + government-cloud branching · KQL extractors (`Remove-KqlComments`, `Get-KqlWatchlistReferences`, `Get-KqlExternalDataReferences`, `Get-KqlBareIdentifiers` incl. `materialize()`/`table('X')` patterns) · `Get-ContentDependencies` orchestrator |
 | Deploy-CustomContent | [`Tests/Test-DeployCustomContent.Tests.ps1`](../../Tests/Test-DeployCustomContent.Tests.ps1) | `Get-PrioritizedFiles`, `Test-ContentDependencies`, `Initialize-DependencyGraph` |
 | Deploy-SentinelContentHub | [`Tests/Test-DeploySentinelContentHub.Tests.ps1`](../../Tests/Test-DeploySentinelContentHub.Tests.ps1) | `Compare-SemanticVersion`, `Test-RuleIsCustomised` |
@@ -485,6 +486,7 @@ tree). Run `Invoke-Pester -Path Tests` for a current total.
 | [`Tests/Test-ImportScriptFunctions.Tests.ps1`](../../Tests/Test-ImportScriptFunctions.Tests.ps1) | AST extractor synthetic + real-repo round-trip | 6 |
 | [`Tests/Test-ParserYaml.Tests.ps1`](../../Tests/Test-ParserYaml.Tests.ps1) | Required fields + KQL identifier validation; functionAlias uniqueness | 4 |
 | [`Tests/Test-PlaybookArm.Tests.ps1`](../../Tests/Test-PlaybookArm.Tests.ps1) | ARM template structure + workflow trigger/action presence | 10 |
+| [`Tests/Test-PullRequestTemplate.Tests.ps1`](../../Tests/Test-PullRequestTemplate.Tests.ps1) | PR-description parsing + required-section / tick-box validation | 16 |
 | [`Tests/Test-SentinelCommon.Tests.ps1`](../../Tests/Test-SentinelCommon.Tests.ps1) | Pipeline logging + REST wrapper + Az context bootstrap + KQL discovery extractors | 57 |
 | [`Tests/Test-SentinelRuleDrift.Tests.ps1`](../../Tests/Test-SentinelRuleDrift.Tests.ps1) | `Compare-SentinelRule`, `Update-RuleYamlFile`, `Get-LineDiff`, `Resolve-RuleSource`, `Save-AbsorbedRule`, `New-AbsorbedRuleYaml`, `ConvertTo-FileSlug` | 58 |
 | [`Tests/Test-SetPlaybookPermissions.Tests.ps1`](../../Tests/Test-SetPlaybookPermissions.Tests.ps1) | `Get-PlaybookRequiredRoles`, `Resolve-Scope` | 14 |

--- a/Tests/Test-PullRequestTemplate.Tests.ps1
+++ b/Tests/Test-PullRequestTemplate.Tests.ps1
@@ -1,0 +1,171 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+
+<#
+.SYNOPSIS
+    Pester 5 tests for the pure functions in
+    Tools/Test-PullRequestTemplate.ps1.
+
+.DESCRIPTION
+    Covers the three functions that own the PR-template parsing and
+    validation:
+
+      - Remove-MarkdownComment
+      - Get-PullRequestSection
+      - Test-PullRequestTemplateBody
+
+    The harness AST-extracts those functions (via the shared
+    Import-ScriptFunctions helper) and dot-sources them, so the script's
+    entry-point (which calls exit) never runs.
+#>
+
+BeforeAll {
+    $repoRoot   = Split-Path -Parent $PSScriptRoot
+    $scriptPath = Join-Path $repoRoot 'Tools/Test-PullRequestTemplate.ps1'
+
+    Import-Module (Join-Path $PSScriptRoot '_helpers/Import-ScriptFunctions.psm1') -Force -ErrorAction Stop
+    Import-ScriptFunctions -Path $scriptPath
+
+    # A description that satisfies every rule. Individual tests mutate a copy
+    # to exercise the failure paths.
+    $script:ValidBody = @'
+## Summary
+
+Adds a Copilot mass sensitive resource access detection rule.
+
+## Why is this change needed?
+
+There is no detection today for large-scale Copilot data access, leaving a visibility gap for exfiltration.
+
+## What does this change do?
+
+Adds the analytical rule YAML and regenerates the dependency manifest so the new rule is tracked.
+
+## What does this fix or affect?
+
+Closes the Copilot exfiltration visibility gap. No behavioural change to existing rules.
+
+## Type of change
+
+- [x] feat - new capability
+- [ ] fix - bug fix
+
+## Testing
+
+Ran ./Tools/Invoke-PRValidation.ps1 locally; every Pester suite passed.
+'@
+}
+
+Describe 'Remove-MarkdownComment' {
+    It 'strips a single inline comment' {
+        Remove-MarkdownComment -Text 'before <!-- hidden --> after' | Should -Be 'before  after'
+    }
+
+    It 'strips a multi-line comment' {
+        $text = "keep`n<!-- line one`nline two -->`nkeep too"
+        $result = Remove-MarkdownComment -Text $text
+        $result | Should -Match 'keep too'
+        $result | Should -Not -Match 'line one'
+    }
+
+    It 'leaves comment-free text untouched' {
+        Remove-MarkdownComment -Text 'plain text' | Should -Be 'plain text'
+    }
+
+    It 'reduces a comment-only string to whitespace' {
+        (Remove-MarkdownComment -Text '<!-- guidance only -->').Trim() | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-PullRequestSection' {
+    It 'splits on level-2 headings only' {
+        $body = "## A`nalpha`n### sub-heading`nbeta`n## B`ngamma"
+        $sections = @(Get-PullRequestSection -Body $body)
+        $sections.Count            | Should -Be 2
+        $sections[0].Heading       | Should -Be 'A'
+        $sections[1].Heading       | Should -Be 'B'
+    }
+
+    It 'keeps deeper headings inside the parent section content' {
+        $body = "## A`nalpha`n### sub-heading`nbeta"
+        $sections = @(Get-PullRequestSection -Body $body)
+        $sections[0].Content | Should -Match 'sub-heading'
+        $sections[0].Content | Should -Match 'beta'
+    }
+
+    It 'trims trailing closing hashes from the heading' {
+        $body = "## Heading ##`nbody"
+        (Get-PullRequestSection -Body $body)[0].Heading | Should -Be 'Heading'
+    }
+
+    It 'ignores content before the first heading' {
+        $body = "leading preamble`n## Real`nbody"
+        $sections = @(Get-PullRequestSection -Body $body)
+        $sections.Count      | Should -Be 1
+        $sections[0].Heading | Should -Be 'Real'
+    }
+}
+
+Describe 'Test-PullRequestTemplateBody' {
+    Context 'a well-formed description' {
+        It 'passes with no errors' {
+            $result = Test-PullRequestTemplateBody -Body $script:ValidBody
+            $result.IsValid      | Should -BeTrue
+            $result.Errors.Count | Should -Be 0
+        }
+
+        It 'accepts an uppercase [X] tick' {
+            $body   = $script:ValidBody -replace '- \[x\] feat', '- [X] feat'
+            $result = Test-PullRequestTemplateBody -Body $body
+            $result.IsValid | Should -BeTrue
+        }
+    }
+
+    Context 'an empty description' {
+        It 'fails on a completely empty body' {
+            $result = Test-PullRequestTemplateBody -Body ''
+            $result.IsValid | Should -BeFalse
+            ($result.Errors -join "`n") | Should -Match 'empty'
+        }
+
+        It 'fails on a whitespace-only body' {
+            $result = Test-PullRequestTemplateBody -Body "   `n`t  "
+            $result.IsValid | Should -BeFalse
+        }
+    }
+
+    Context 'a missing required section' {
+        It 'fails when "Why is this change needed?" is removed' {
+            $body   = $script:ValidBody -replace '(?s)## Why is this change needed\?.*?(?=## What does this change do\?)', ''
+            $result = Test-PullRequestTemplateBody -Body $body
+            $result.IsValid | Should -BeFalse
+            ($result.Errors -join "`n") | Should -Match 'Why is this change needed'
+        }
+    }
+
+    Context 'a section left as the placeholder' {
+        It 'fails when Summary holds only a guidance comment' {
+            $body   = $script:ValidBody -replace 'Adds a Copilot mass sensitive resource access detection rule\.', '<!-- one or two sentences -->'
+            $result = Test-PullRequestTemplateBody -Body $body
+            $result.IsValid | Should -BeFalse
+            ($result.Errors -join "`n") | Should -Match "Section '## Summary' is empty"
+        }
+    }
+
+    Context 'no type-of-change box ticked' {
+        It 'fails when every box is unchecked' {
+            $body   = $script:ValidBody -replace '- \[x\] feat - new capability', '- [ ] feat - new capability'
+            $result = Test-PullRequestTemplateBody -Body $body
+            $result.IsValid | Should -BeFalse
+            ($result.Errors -join "`n") | Should -Match 'box is ticked'
+        }
+    }
+
+    Context 'multiple problems at once' {
+        It 'reports one error per failing rule' {
+            $body   = "## Summary`n`n<!-- nothing -->`n`n## Type of change`n`n- [ ] feat - new capability"
+            $result = Test-PullRequestTemplateBody -Body $body
+            $result.IsValid      | Should -BeFalse
+            $result.Errors.Count | Should -BeGreaterThan 1
+        }
+    }
+}

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -1,0 +1,279 @@
+#
+# Sentinel-As-Code/Tools/Test-PullRequestTemplate.ps1
+#
+# Created by noodlemctwoodle on 08/07/2026.
+#
+
+#Requires -Version 7.2
+
+<#
+.SYNOPSIS
+    Validates that a pull-request description follows
+    .github/PULL_REQUEST_TEMPLATE.md. Fails (exit 1) when a required
+    section is missing, left as the placeholder guidance, or the
+    "Type of change" taxonomy has no box ticked. Called by the
+    "PR Template Validation" GitHub Actions workflow so an under-filled
+    PR body blocks the merge gate.
+
+.DESCRIPTION
+    The PR template asks the author WHY the change is needed, WHAT it
+    does, what it fixes / affects, and how it was tested. Reviewers rely
+    on that context, so an empty or copy-paste body wastes review time.
+    This script turns the template's required sections into an
+    enforceable check.
+
+    What it enforces (each a hard failure):
+
+      1. The description is not empty.
+      2. Every required prose section is present AND holds real content
+         once the HTML guidance comments are stripped:
+           - Summary
+           - Why is this change needed?
+           - What does this change do?
+           - Testing
+      3. The "Type of change" section has at least one ticked box ([x]).
+
+    What it deliberately does NOT enforce (kept optional so contributors
+    are not pushed into writing "N/A" noise):
+
+      - "What does this fix or affect?", "Files changed",
+        "Pre-merge checklist", and "Related" sections.
+
+    The parsing logic lives in small pure functions
+    (Get-PullRequestSection, Remove-MarkdownComment,
+    Test-PullRequestTemplateBody) so it can be unit-tested via the
+    repo's AST-extraction pattern without running this entry-point.
+    See Tests/Test-PullRequestTemplate.Tests.ps1.
+
+.PARAMETER Body
+    The raw PR description (Markdown). In CI this is passed from
+    github.event.pull_request.body via an environment variable so the
+    untrusted body is never interpolated into a shell command.
+
+.PARAMETER BodyPath
+    Alternative to -Body: a path to a file containing the PR
+    description. -Body wins if both are supplied.
+
+.EXAMPLE
+    ./Tools/Test-PullRequestTemplate.ps1 -Body $env:PR_BODY
+
+    Validates the body captured in the PR_BODY environment variable.
+    Exits 1 (with a per-failure list) if the template is under-filled.
+
+.EXAMPLE
+    ./Tools/Test-PullRequestTemplate.ps1 -BodyPath ./pr-body.md
+
+    Validates a description read from a file. Handy for local testing.
+
+.NOTES
+    Author:         noodlemctwoodle
+    Version:        1.0.0
+    Last Updated:   2026-07-08
+    Repository:     Sentinel-As-Code
+    Requires:       PowerShell 7.2+, Sentinel.Common (logging only)
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [AllowEmptyString()]
+    [string]$Body
+    ,
+    [Parameter(Mandatory = $false)]
+    [string]$BodyPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Logging only. Importing Sentinel.Common keeps the ADO / GitHub / local
+# output branching in one place (Write-PipelineMessage) rather than
+# reimplementing it here, per the repo's PowerShell hard rules. The
+# module's Az.Accounts requirement is satisfied by the runner image (the
+# dependency-manifest gate imports the same module the same way).
+Import-Module (Join-Path $PSScriptRoot '../Modules/Sentinel.Common/Sentinel.Common.psd1') -Force -ErrorAction Stop
+
+# ---------------------------------------------------------------------------
+# Remove-MarkdownComment
+# ---------------------------------------------------------------------------
+# Strips HTML comment blocks (<!-- ... -->) from a chunk of Markdown. The
+# template's guidance lives in these comments; stripping them is what lets
+# us tell "author wrote a real description" from "author left the template
+# untouched".
+function Remove-MarkdownComment {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    # (?s) so '.' spans newlines; non-greedy so adjacent comments don't merge.
+    return [regex]::Replace($Text, '(?s)<!--.*?-->', '')
+}
+
+# ---------------------------------------------------------------------------
+# Get-PullRequestSection
+# ---------------------------------------------------------------------------
+# Splits a PR body into its level-2 (## ) sections. Returns an ordered list
+# of objects { Heading; Content }. Only '## ' headings start a new section;
+# deeper headings (### and beyond) stay part of the current section's
+# content, so an author's sub-headings never accidentally split a section.
+function Get-PullRequestSection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Body
+    )
+
+    $sections = [System.Collections.Generic.List[object]]::new()
+    $heading  = $null
+    $buffer   = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($line in ($Body -split '\r?\n')) {
+        # Exactly two hashes followed by whitespace: '## Heading' (optionally
+        # with trailing closing hashes). '### ...' does not match.
+        if ($line -match '^\s{0,3}#{2}\s+(.+?)\s*#*\s*$') {
+            if ($null -ne $heading) {
+                $sections.Add([pscustomobject]@{
+                    Heading = $heading
+                    Content = ($buffer.ToArray() -join "`n")
+                })
+            }
+            $heading = $Matches[1].Trim()
+            $buffer  = [System.Collections.Generic.List[string]]::new()
+        }
+        elseif ($null -ne $heading) {
+            $buffer.Add($line)
+        }
+    }
+
+    if ($null -ne $heading) {
+        $sections.Add([pscustomobject]@{
+            Heading = $heading
+            Content = ($buffer.ToArray() -join "`n")
+        })
+    }
+
+    return $sections
+}
+
+# ---------------------------------------------------------------------------
+# Test-PullRequestTemplateBody
+# ---------------------------------------------------------------------------
+# Pure validator. Takes the raw PR body, returns a result object
+# { IsValid; Errors }. No console output and no exit - the entry-point
+# below renders the result. This shape is what the Pester suite asserts on.
+function Test-PullRequestTemplateBody {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Body
+    )
+
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    # Required prose sections: heading text must be present AND, once the
+    # guidance comments are stripped, hold at least $minContentChars of
+    # non-whitespace text.
+    $requiredProse = @(
+        'Summary'
+        'Why is this change needed?'
+        'What does this change do?'
+        'Testing'
+    )
+    # Section that must carry at least one ticked checkbox.
+    $requiredChoice  = 'Type of change'
+    $minContentChars = 10
+
+    if ([string]::IsNullOrWhiteSpace($Body)) {
+        $errors.Add('The pull request description is empty. Fill in the PR template (why the change is needed, what it does, what it fixes, and how it was tested).')
+        return [pscustomobject]@{ IsValid = $false; Errors = $errors.ToArray() }
+    }
+
+    $sections = Get-PullRequestSection -Body $Body
+
+    foreach ($required in $requiredProse) {
+        $section = $sections | Where-Object { $_.Heading -ieq $required } | Select-Object -First 1
+        if (-not $section) {
+            $errors.Add("Required section '## $required' is missing. Do not delete it from the template.")
+            continue
+        }
+
+        $content  = Remove-MarkdownComment -Text $section.Content
+        $stripped = ($content -replace '\s', '')
+        if ($stripped.Length -lt $minContentChars) {
+            $errors.Add("Section '## $required' is empty. Replace the placeholder guidance with a real description.")
+        }
+    }
+
+    $choice = $sections | Where-Object { $_.Heading -ieq $requiredChoice } | Select-Object -First 1
+    if (-not $choice) {
+        $errors.Add("Required section '## $requiredChoice' is missing. Do not delete it from the template.")
+    }
+    elseif ($choice.Content -notmatch '(?im)^\s*[-*]\s*\[x\]') {
+        $errors.Add("No '## $requiredChoice' box is ticked. Mark at least one option with [x].")
+    }
+
+    return [pscustomobject]@{
+        IsValid = ($errors.Count -eq 0)
+        Errors  = $errors.ToArray()
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Entry-point
+# ---------------------------------------------------------------------------
+# Not a function, so the AST-extraction test harness skips it: the Pester
+# suite dot-sources only the functions above and never triggers this block
+# (which would call exit).
+$resolvedBody = $Body
+if ([string]::IsNullOrEmpty($resolvedBody) -and $BodyPath) {
+    if (Test-Path -LiteralPath $BodyPath) {
+        $resolvedBody = Get-Content -LiteralPath $BodyPath -Raw
+    }
+    else {
+        Write-PipelineMessage -Level Error -Message "BodyPath not found: $BodyPath"
+        exit 1
+    }
+}
+if ($null -eq $resolvedBody) { $resolvedBody = '' }
+
+$result = Test-PullRequestTemplateBody -Body $resolvedBody
+
+if ($result.IsValid) {
+    Write-PipelineMessage -Level Success -Message 'PR template validation passed.'
+    exit 0
+}
+
+Write-PipelineMessage -Level Section -Message 'PR template validation failed. Fix the description and the check re-runs when you save it.'
+
+# Emit each failure as a GitHub workflow annotation when running in Actions
+# (Write-PipelineMessage only knows ADO / local), otherwise a plain bullet.
+# This keeps the annotation support the shared helper lacks without
+# duplicating its ADO / local branching.
+$inGitHub = $env:GITHUB_ACTIONS -eq 'true'
+foreach ($failure in $result.Errors) {
+    if ($inGitHub) {
+        Write-Host "::error::$failure"
+    }
+    else {
+        Write-Host "  - $failure"
+    }
+}
+
+# Render a compact summary on the GitHub Actions run page when available.
+if ($env:GITHUB_STEP_SUMMARY) {
+    $summary = [System.Collections.Generic.List[string]]::new()
+    [void]$summary.Add('## PR template validation failed')
+    [void]$summary.Add('')
+    [void]$summary.Add('The pull request description does not satisfy `.github/PULL_REQUEST_TEMPLATE.md`. Fix the items below and the check will re-run when you save the description.')
+    [void]$summary.Add('')
+    foreach ($failure in $result.Errors) {
+        [void]$summary.Add("- $failure")
+    }
+    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value ($summary.ToArray() -join "`n")
+}
+
+exit 1

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -228,8 +228,12 @@ function Test-PullRequestTemplateBody {
 # Not a function, so the AST-extraction test harness skips it: the Pester
 # suite dot-sources only the functions above and never triggers this block
 # (which would call exit).
-$resolvedBody = $Body
-if ([string]::IsNullOrEmpty($resolvedBody) -and $BodyPath) {
+# -Body wins whenever it was explicitly passed (even as an empty string), per
+# the parameter help. Fall back to -BodyPath only when -Body was not supplied.
+if ($PSBoundParameters.ContainsKey('Body')) {
+    $resolvedBody = $Body
+}
+elseif ($BodyPath) {
     if (Test-Path -LiteralPath $BodyPath) {
         $resolvedBody = Get-Content -LiteralPath $BodyPath -Raw
     }
@@ -237,6 +241,9 @@ if ([string]::IsNullOrEmpty($resolvedBody) -and $BodyPath) {
         Write-PipelineMessage -Level Error -Message "BodyPath not found: $BodyPath"
         exit 1
     }
+}
+else {
+    $resolvedBody = ''
 }
 if ($null -eq $resolvedBody) { $resolvedBody = '' }
 

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -188,7 +188,7 @@ function Test-PullRequestTemplateBody {
     $minContentChars = 10
 
     if ([string]::IsNullOrWhiteSpace($Body)) {
-        $errors.Add('The pull request description is empty. Fill in the PR template (why the change is needed, what it does, what it fixes, and how it was tested).')
+        $errors.Add('The pull request description is empty. Fill in the PR template (the summary, why the change is needed, what it does, and how it was tested).')
         return [pscustomobject]@{ IsValid = $false; Errors = $errors.ToArray() }
     }
 


### PR DESCRIPTION
## Summary

Adds a PR Template Validation gate: an enriched pull-request template plus a GitHub Actions check that fails any PR whose description is not properly filled in.

## Why is this change needed?

The previous template explicitly said "empty sections are fine", so PRs routinely arrived with no motivation, no description of the change, and no testing notes. Reviewers then had to reverse-engineer intent from the diff. This turns the template into an enforceable contract so the why / what / fixes context is always present before review.

## What does this change do?

Restructures `.github/PULL_REQUEST_TEMPLATE.md` into detailed sections (Summary, Why is this change needed?, What does this change do?, What does this fix or affect?, Type of change, Testing, and more) and adds `.github/workflows/pr-template-validation.yml`, which parses the PR body via `Tools/Test-PullRequestTemplate.ps1` and fails the `template` status check when a required section is empty or no Type-of-change box is ticked. The workflow re-runs on the `edited` event so fixing the description clears the check without a new commit, and it skips bot / `auto/*` PRs.

## What does this fix or affect?

Affects contributor workflow: every human PR must now fill in the required sections. No behavioural change to deploy pipelines or content. Bot-authored auto-sync PRs are exempt. Making the check blocking requires adding `template` to the Main Branch Protection ruleset (one-off manual step).

## Type of change

- [x] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [ ] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [x] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Files changed (high level)

- `.github/PULL_REQUEST_TEMPLATE.md` - richer, enforceable template
- `.github/workflows/pr-template-validation.yml` - new validation workflow (GitHub-only)
- `Tools/Test-PullRequestTemplate.ps1` - the validator (pure, testable functions)
- `Tests/Test-PullRequestTemplate.Tests.ps1` - 16-test Pester suite
- Docs + inventories (Pipelines.md, Scripts.md, Pester-Tests.md, workflows.instructions.md) and the 17 to 18 test-file count

## Testing

- `./Tools/Invoke-PRValidation.ps1 -InstallModules:$false` - 6602 passed, 0 failed, 391 skipped.
- Ran the validator against the unfilled template (fails, exit 1) and a filled body (passes, exit 0), including the GitHub `::error::` annotation path.

## Related

GitHub-only by design (platform-forced divergence per `.github/instructions/workflows.instructions.md` Hard rule 1): the PR body lives in the Actions event payload, which has no ADO build-validation equivalent.
