### PR TITLE
docs(releases): 26.07.1 - Copilot content pack, authoring toolkit, PR-template gate

### DIFF
--- a/Docs/Releases/CHANGELOG.md
+++ b/Docs/Releases/CHANGELOG.md
@@ -9,16 +9,16 @@ label (now retired); the wave → CalVer mapping is in [Versioning](Versioning.m
 - **Copilot activity monitoring content pack** — detection and hunting content
   for Microsoft 365 Copilot and Security Copilot usage across the
   `CloudAppEvents`, `CopilotActivity`, and `OfficeActivity` tables: six
-  analytics rules, one Defender XDR custom detection, thirteen hunting queries,
+  analytics rules, one Defender XDR custom detection, fourteen hunting queries,
   and the `CopilotEntitledUsers` watchlist backing the unentitled-usage
   detections.
 - **Sentinel as Code Toolkit** — a companion VS Code extension for authoring
-  Sentinel-as-Code content without leaving the editor: real-time schema
+  Sentinel-As-Code content without leaving the editor: real-time schema
   validation, IntelliSense, canonical formatting, and templates for analytics
   rules and hunting queries; ARM-template-to-YAML decompilation; and repository
   formatting for Defender XDR custom detections, automation rules, summary
-  rules, watchlists, workbooks, and playbooks. Publishing to the Visual Studio
-  Marketplace later this week.
+  rules, watchlists, workbooks, and playbooks. Available on the Visual Studio
+  Marketplace.
 - **PR template validation gate** — an enriched pull-request template plus a
   GitHub Actions check that fails any PR whose description is not filled in
   (Summary, why the change is needed, what it does, and testing, with a ticked

--- a/Docs/Releases/CHANGELOG.md
+++ b/Docs/Releases/CHANGELOG.md
@@ -4,6 +4,26 @@ Customer-facing changes to Sentinel-As-Code, newest first. Releases use CalVer
 (`YY.0M`) — see [Versioning](Versioning.md). "Wave N" was the previous release
 label (now retired); the wave → CalVer mapping is in [Versioning](Versioning.md).
 
+## 26.07.1
+
+- **Copilot activity monitoring content pack** — detection and hunting content
+  for Microsoft 365 Copilot and Security Copilot usage across the
+  `CloudAppEvents`, `CopilotActivity`, and `OfficeActivity` tables: six
+  analytics rules, one Defender XDR custom detection, thirteen hunting queries,
+  and the `CopilotEntitledUsers` watchlist backing the unentitled-usage
+  detections.
+- **Sentinel as Code Toolkit** — a companion VS Code extension for authoring
+  Sentinel-as-Code content without leaving the editor: real-time schema
+  validation, IntelliSense, canonical formatting, and templates for analytics
+  rules and hunting queries; ARM-template-to-YAML decompilation; and repository
+  formatting for Defender XDR custom detections, automation rules, summary
+  rules, watchlists, workbooks, and playbooks. Publishing to the Visual Studio
+  Marketplace later this week.
+- **PR template validation gate** — an enriched pull-request template plus a
+  GitHub Actions check that fails any PR whose description is not filled in
+  (Summary, why the change is needed, what it does, and testing, with a ticked
+  change type), so reviewers get the context up front.
+
 ## 26.07
 
 - **Word report generation** — a pandoc-based converter renders the Sentinel

--- a/Docs/Releases/Versioning.md
+++ b/Docs/Releases/Versioning.md
@@ -58,7 +58,7 @@ immutable git history). The mapping:
 | Wave 4 | `26.06.0` | PR #25 |
 | Repository restructure | `26.06.1` | first tagged release |
 | Word report + Apache-2.0 relicence | `26.07` | PR #29 |
-| Copilot content pack, authoring toolkit, PR-template gate | `26.07.1` | PRs #30, #31 |
+| Copilot activity monitoring content pack, Sentinel as Code Toolkit, PR template validation gate | `26.07.1` | PR #30, PR #31 |
 
 Tagging begins at `v26.06.1`; earlier releases are recorded here for reference
 and are not retroactively tagged.

--- a/Docs/Releases/Versioning.md
+++ b/Docs/Releases/Versioning.md
@@ -58,6 +58,7 @@ immutable git history). The mapping:
 | Wave 4 | `26.06.0` | PR #25 |
 | Repository restructure | `26.06.1` | first tagged release |
 | Word report + Apache-2.0 relicence | `26.07` | PR #29 |
+| Copilot content pack, authoring toolkit, PR-template gate | `26.07.1` | PRs #30, #31 |
 
 Tagging begins at `v26.06.1`; earlier releases are recorded here for reference
 and are not retroactively tagged.


### PR DESCRIPTION
## Summary

Prepares the **26.07.1** release notes: bumps the changelog and versioning history to bundle the two open feature PRs plus the companion authoring toolkit.

## Why is this change needed?

Release 26.07.1 groups the Copilot activity content pack (#30) and the PR template validation gate (#31) with the upcoming Sentinel as Code Toolkit. The customer-facing changelog and the versioning history table need to reflect the release before it is tagged.

## What does this change do?

Adds a `## 26.07.1` section to `Docs/Releases/CHANGELOG.md` and a matching row to the history table in `Docs/Releases/Versioning.md`. The entry documents:

- **Copilot activity monitoring content pack** (PR #30) - 6 analytics rules, 1 Defender XDR custom detection, 13 hunting queries, and the `CopilotEntitledUsers` watchlist.
- **Sentinel as Code Toolkit** - companion VS Code authoring extension (validation, formatting, templates, ARM-to-YAML decompile), publishing to the Visual Studio Marketplace later this week.
- **PR template validation gate** (PR #31).

## What does this fix or affect?

Documentation only - no code, content, KQL, or Bicep changes. Sequencing: this release PR should merge **after** PRs #30 and #31 so the notes match what is on main, then tag `v26.07.1` on the merge commit per `Docs/Releases/Versioning.md`.

## Type of change

- [ ] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [x] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [ ] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Testing

Documentation-only change. `Docs/Releases/` is not covered by any Pester suite, so no test run is required; the PR-validation gate (validate / bicep-build / kql-validate / dependency-manifest) has nothing to act on and stays green.

## Related

- PR #30 - Copilot activity monitoring content pack
- PR #31 - PR template validation gate
- Sentinel as Code Toolkit (companion VS Code extension, Marketplace publish this week)
