### PR TITLE
docs(toolkit): reconcile Toolkit docs with YAML-first authoring

### DIFF
--- a/Docs/Content/Automation-Rules.md
+++ b/Docs/Content/Automation-Rules.md
@@ -14,7 +14,7 @@ The Sentinel as Code Toolkit scaffolds and validates this content type. Its bund
 
 ## Folder Structure
 
-Each automation rule is stored as a single JSON file. The Toolkit's `automation-rule` template is authored as commented YAML for readability, and the extension converts it to JSON on disk when you scaffold a rule (automation rules are one of the three content types the Toolkit stores as JSON rather than YAML). Files can be placed directly in the folder or organised into subfolders by function or environment:
+Each automation rule is stored as a single JSON file. The Toolkit's `automation-rule` template is authored as commented YAML for readability; you run its Convert Content YAML to JSON command to produce the JSON stored on disk when you are ready to deploy (automation rules are one of the three content types the pipeline stores as JSON rather than YAML). Files can be placed directly in the folder or organised into subfolders by function or environment:
 
 ```
 Content/AutomationRules/

--- a/Docs/Content/Summary-Rules.md
+++ b/Docs/Content/Summary-Rules.md
@@ -48,7 +48,7 @@ Content/SummaryRules/
 
 Each summary rule is defined as a single JSON file. The top-level keys map directly to the `ruleDefinition` block in the REST API body, with `name`, `description`, and `displayName` promoted to the top level for readability.
 
-The authoring contract below (field names, required-vs-optional, types, patterns, and allowed values) is defined by the Sentinel as Code Toolkit schema `sentinel-summary-rule-schema.json`. The Toolkit scaffolds summary rules from a commented YAML template and converts them to the JSON form stored on disk here, and validates them against the same schema in the editor. See [Toolkit Templates](../Toolkit/Templates.md) and [Schemas and Validation](../Toolkit/Schemas-and-Validation.md).
+The authoring contract below (field names, required-vs-optional, types, patterns, and allowed values) is defined by the Sentinel as Code Toolkit schema `sentinel-summary-rule-schema.json`. The Toolkit scaffolds summary rules as a commented YAML template; you author the YAML, then run its Convert Content YAML to JSON command to produce the JSON form stored on disk here, and it validates that JSON against the same schema in the editor. See [Toolkit Templates](../Toolkit/Templates.md) and [Schemas and Validation](../Toolkit/Schemas-and-Validation.md).
 
 ### Required Fields
 

--- a/Docs/Content/Watchlists.md
+++ b/Docs/Content/Watchlists.md
@@ -101,8 +101,9 @@ deploy and cross-validate as `Bar`.
 
 Keeping the folder name equal to the alias is a useful convention (every
 folder under `Content/Watchlists/` follows it today, and the Toolkit's
-"Create Watchlist from CSV" command scaffolds the folder and alias with
-the same name) but the deploy pipeline does not enforce it. What is
+"Create Watchlist from CSV" command scaffolds a `watchlist.yaml` alongside
+its data file for you to set the alias in before converting to
+`watchlist.json`) but the deploy pipeline does not enforce it. What is
 enforced, by `Test-WatchlistJson.Tests.ps1` in the
 PR-validation gate, is:
 

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -125,7 +125,7 @@ not deploy. Its schemas and templates are the authoring source of truth for the
 | --- | --- |
 | [Toolkit overview](Toolkit/README.md) | What the extension is, the author/deploy boundary, installation, licence, and feedback channel |
 | [Commands](Toolkit/Commands.md) | Every command the extension contributes, grouped by task, with palette titles and keybindings |
-| [Templates](Toolkit/Templates.md) | The bundled starter templates, canonical field order, and which content types convert from YAML to JSON on scaffold |
+| [Templates](Toolkit/Templates.md) | The bundled starter templates, canonical field order, and which content types are authored as YAML and converted to JSON with **Convert Content YAML to JSON** |
 | [Schemas and Validation](Toolkit/Schemas-and-Validation.md) | The seven bundled schemas, how validation is triggered, and MITRE ATT&CK multi-framework checking |
 | [Configuration](Toolkit/Configuration.md) | Every `sentinelAsCode.*` setting, its default, and the custom-connectors file |
 | [ARM to YAML Conversion](Toolkit/ARM-to-YAML-Conversion.md) | Decompiling `Microsoft.SecurityInsights/alertRules` ARM templates into clean analytics-rule YAML |

--- a/Docs/Toolkit/Commands.md
+++ b/Docs/Toolkit/Commands.md
@@ -38,7 +38,7 @@ Commands for creating a new analytics rule and for managing rule IDs. See [Templ
 
 ## Content Scaffolding
 
-Commands for creating each non-analytics content type. Every content type is scaffolded as commented YAML, and the scaffolder asks where to save it rather than prompting for each field. Analytics rules, hunting queries and parsers deploy as that YAML, while summary rules, automation rules and watchlists are authored as YAML and then converted with **Convert Content YAML to JSON**, which writes the `<name>.json` the pipeline stores. See [Templates](Templates.md) for details.
+Commands for creating each non-analytics content type. Every content type is scaffolded as commented YAML, and the scaffolder asks where to save it rather than prompting for each field. Analytics rules, hunting queries and parsers deploy as that YAML, while summary rules, automation rules and watchlists are authored as YAML and then converted with **Convert Content YAML to JSON**, which writes the JSON the pipeline stores beside the source, keeping its base name (a summary or automation rule becomes `<name>.json`; a watchlist's `watchlist.yaml` becomes `watchlist.json`). See [Templates](Templates.md) for details.
 
 | Palette title | What it does | Keybinding | Menus |
 |---------------|--------------|------------|-------|
@@ -48,7 +48,7 @@ Commands for creating each non-analytics content type. Every content type is sca
 | `Sentinel-As-Code: New Summary Rule` | Scaffolds a summary rule as commented YAML. Author the field values, then run **Convert Content YAML to JSON** to produce the `.json` the pipeline stores. See [Summary Rules](../Content/Summary-Rules.md). | - | Palette |
 | `Sentinel-As-Code: New Automation Rule` | Scaffolds an automation rule as commented YAML. Author the field values, then run **Convert Content YAML to JSON** to produce the `.json` the pipeline stores. See [Automation Rules](../Content/Automation-Rules.md). | - | Palette |
 | `Sentinel-As-Code: Create Watchlist from CSV` | Turns a `.csv` or `.tsv` file into a watchlist under `Content/Watchlists/<alias>/`, writing a `watchlist.yaml` template plus the data file. Set `watchlistAlias` and `itemsSearchKey` in the YAML, then run **Convert Content YAML to JSON** to produce the `watchlist.json` the pipeline deploys. See [Watchlists](../Content/Watchlists.md). | - | Editor (`.csv`/`.tsv`) and Palette (with a `.csv`/`.tsv` open) |
-| `Sentinel-As-Code: Convert Content YAML to JSON` | Converts an authored summary rule, automation rule or watchlist YAML into the JSON the pipeline stores, writing `<name>.json` beside the source. See [Templates](Templates.md). | - | Editor and Explorer (`.yaml`/`.yml`), and Palette |
+| `Sentinel-As-Code: Convert Content YAML to JSON` | Converts an authored summary rule, automation rule or watchlist YAML into the JSON the pipeline stores, writing a `.json` beside the source with the same base name (a rule becomes `<name>.json`; a `watchlist.yaml` becomes `watchlist.json`). See [Templates](Templates.md). | - | Editor and Explorer (`.yaml`/`.yml`), and Palette |
 | `Sentinel-As-Code: Populate Required Data Connectors from Query` | Reads the KQL tables referenced by the rule's query and fills in `requiredDataConnectors` from the bundled Content Hub mapping. Unknown `_CL` tables are registered into a workspace-local `.sentinel-connectors.json`. | - | Editor (`.yaml`/`.yml`) and Palette (with a `.yaml`/`.yml` open) |
 
 ## ARM Conversion

--- a/Docs/Toolkit/Commands.md
+++ b/Docs/Toolkit/Commands.md
@@ -1,6 +1,6 @@
 # Toolkit Commands
 
-The Sentinel as Code Toolkit contributes 25 commands to VS Code. Every command is a Command Palette entry, grouped under one of two categories: **Sentinel-As-Code** (Sentinel content) or **Defender-As-Code** (Microsoft Defender XDR custom detections). A handful also appear on right-click menus or carry a keyboard shortcut.
+The Sentinel as Code Toolkit contributes 26 commands to VS Code. Every command is a Command Palette entry, grouped under one of two categories: **Sentinel-As-Code** (Sentinel content) or **Defender-As-Code** (Microsoft Defender XDR custom detections). A handful also appear on right-click menus or carry a keyboard shortcut.
 
 The Toolkit authors and validates content; it does not deploy. Scaffolding, formatting, conversion and validation all happen locally in your editor, and the [Sentinel-As-Code pipeline](../../README.md) does the deployment.
 
@@ -18,7 +18,7 @@ Palette entries are shown with their category prefix, exactly as they read in th
 | Group | Commands |
 |-------|----------|
 | [Rule and content authoring](#rule-and-content-authoring) | Create Sentinel Rule Template, Generate Rule Template, Generate Standard Rule Template, Generate NRT Rule Template, Generate New Rule ID, Generate New IDs for All Rules |
-| [Content scaffolding](#content-scaffolding) | New Sentinel-as-Code Content, New Hunting Query, New Parser, New Summary Rule, New Automation Rule, Create Watchlist from CSV, Populate Required Data Connectors from Query |
+| [Content scaffolding](#content-scaffolding) | New Sentinel-as-Code Content, New Hunting Query, New Parser, New Summary Rule, New Automation Rule, Create Watchlist from CSV, Convert Content YAML to JSON, Populate Required Data Connectors from Query |
 | [ARM conversion](#arm-conversion) | Decompile ARM to YAML |
 | [Validation and formatting](#validation-and-formatting) | Fix Field Order, Format Sentinel Rule, Format Sentinel Content, Validate Rule, Validate as Sentinel Analytics Rule, Bulk Maintenance and Validation |
 | [Defender custom detections](#defender-custom-detections) | Generate Custom Detection Template, Format Custom Detection for Repo, Convert Custom Detection YAML to JSON, Convert Custom Detection JSON to YAML, Validate as Custom Detection |
@@ -38,16 +38,17 @@ Commands for creating a new analytics rule and for managing rule IDs. See [Templ
 
 ## Content Scaffolding
 
-Commands for creating each non-analytics content type. The Toolkit writes the correct on-disk format for you: analytics rules, hunting queries and parsers are stored as YAML, while summary rules, automation rules and watchlists are converted to JSON on disk automatically when scaffolded. See [Templates](Templates.md) for details.
+Commands for creating each non-analytics content type. Every content type is scaffolded as commented YAML, and the scaffolder asks where to save it rather than prompting for each field. Analytics rules, hunting queries and parsers deploy as that YAML, while summary rules, automation rules and watchlists are authored as YAML and then converted with **Convert Content YAML to JSON**, which writes the `<name>.json` the pipeline stores. See [Templates](Templates.md) for details.
 
 | Palette title | What it does | Keybinding | Menus |
 |---------------|--------------|------------|-------|
-| `Sentinel-As-Code: New Sentinel-as-Code Content...` | Single entry point that prompts for the content type (hunting query, parser, summary rule, automation rule, and so on), then scaffolds it in the right folder and format. | - | Palette |
+| `Sentinel-As-Code: New Sentinel-as-Code Content...` | Single entry point for scaffolding any content type. Pick a type, then choose where to save it. The two types with more than one source add a second step: Analytics Rule offers Standard, NRT or Decompile from an ARM template; Watchlist offers a blank template or one built from the active CSV/TSV. | - | Palette and Explorer (right-click a folder) |
 | `Sentinel-As-Code: New Hunting Query` | Scaffolds a hunting-query YAML file from the template. See [Hunting Queries](../Content/Hunting-Queries.md). | - | Palette |
 | `Sentinel-As-Code: New Parser` | Scaffolds a parser (KQL function) YAML file from the template. See [Parsers](../Content/Parsers.md). | - | Palette |
-| `Sentinel-As-Code: New Summary Rule` | Scaffolds a summary rule. The template is authored as YAML and written to disk as JSON. See [Summary Rules](../Content/Summary-Rules.md). | - | Palette |
-| `Sentinel-As-Code: New Automation Rule` | Scaffolds an automation rule. The template is authored as YAML and written to disk as JSON. See [Automation Rules](../Content/Automation-Rules.md). | - | Palette |
-| `Sentinel-As-Code: Create Watchlist from CSV` | Turns a `.csv` or `.tsv` file into a watchlist under `Content/Watchlists/<alias>/`, writing both `watchlist.json` and the data file. See [Watchlists](../Content/Watchlists.md). | - | Editor (`.csv`/`.tsv`) and Palette (with a `.csv`/`.tsv` open) |
+| `Sentinel-As-Code: New Summary Rule` | Scaffolds a summary rule as commented YAML. Author the field values, then run **Convert Content YAML to JSON** to produce the `.json` the pipeline stores. See [Summary Rules](../Content/Summary-Rules.md). | - | Palette |
+| `Sentinel-As-Code: New Automation Rule` | Scaffolds an automation rule as commented YAML. Author the field values, then run **Convert Content YAML to JSON** to produce the `.json` the pipeline stores. See [Automation Rules](../Content/Automation-Rules.md). | - | Palette |
+| `Sentinel-As-Code: Create Watchlist from CSV` | Turns a `.csv` or `.tsv` file into a watchlist under `Content/Watchlists/<alias>/`, writing a `watchlist.yaml` template plus the data file. Set `watchlistAlias` and `itemsSearchKey` in the YAML, then run **Convert Content YAML to JSON** to produce the `watchlist.json` the pipeline deploys. See [Watchlists](../Content/Watchlists.md). | - | Editor (`.csv`/`.tsv`) and Palette (with a `.csv`/`.tsv` open) |
+| `Sentinel-As-Code: Convert Content YAML to JSON` | Converts an authored summary rule, automation rule or watchlist YAML into the JSON the pipeline stores, writing `<name>.json` beside the source. See [Templates](Templates.md). | - | Editor and Explorer (`.yaml`/`.yml`), and Palette |
 | `Sentinel-As-Code: Populate Required Data Connectors from Query` | Reads the KQL tables referenced by the rule's query and fills in `requiredDataConnectors` from the bundled Content Hub mapping. Unknown `_CL` tables are registered into a workspace-local `.sentinel-connectors.json`. | - | Editor (`.yaml`/`.yml`) and Palette (with a `.yaml`/`.yml` open) |
 
 ## ARM Conversion
@@ -98,6 +99,8 @@ For quick reference, the commands that appear on right-click menus and the file 
 | Decompile ARM to YAML | `.json` (conversion enabled) | `.json` (conversion enabled) |
 | Create Watchlist from CSV | `.csv` / `.tsv` | - |
 | Populate Required Data Connectors from Query | `.yaml` / `.yml` | - |
+| Convert Content YAML to JSON | `.yaml` / `.yml` | `.yaml` / `.yml` |
+| New Sentinel-as-Code Content... | - | Folders |
 | Create Sentinel Rule Template... | - | Folders |
 
 ## Related Documentation

--- a/Docs/Toolkit/README.md
+++ b/Docs/Toolkit/README.md
@@ -103,7 +103,7 @@ under those terms.
 | Doc | What it covers |
 | --- | --- |
 | [Commands](Commands.md) | Every command the extension contributes, grouped by task, with palette titles and keybindings |
-| [Templates](Templates.md) | The bundled starter templates, canonical field order, and which content types are converted from YAML to JSON on scaffold |
+| [Templates](Templates.md) | The bundled starter templates, canonical field order, and which content types are authored as YAML and converted to JSON with **Convert Content YAML to JSON** |
 | [Schemas and Validation](Schemas-and-Validation.md) | The seven bundled schemas, how validation is triggered, and MITRE ATT&CK multi-framework checking |
 | [Configuration](Configuration.md) | Every `sentinelAsCode.*` setting, its default, and the custom-connectors file |
 | [ARM to YAML Conversion](ARM-to-YAML-Conversion.md) | Decompiling `Microsoft.SecurityInsights/alertRules` ARM templates into clean analytics-rule YAML |

--- a/Docs/Toolkit/Schemas-and-Validation.md
+++ b/Docs/Toolkit/Schemas-and-Validation.md
@@ -36,7 +36,8 @@ authoring doc. All seven are JSON Schema draft-07 files under the extension's
 
 Analytics rules, hunting queries, parsers and Defender detections are authored as
 YAML. Summary rules, automation rules and watchlists are stored as JSON on disk,
-and the Toolkit converts them from YAML to JSON when it scaffolds them (see
+and the Toolkit authors them as commented YAML, then converts them to JSON with its
+Convert Content YAML to JSON command (see
 [Templates](Templates.md)). The schema for each type validates the on-disk
 format shown above.
 

--- a/Docs/Toolkit/Templates.md
+++ b/Docs/Toolkit/Templates.md
@@ -4,7 +4,7 @@
 
 The Sentinel as Code Toolkit ships eight bundled starter templates, one for each content type the Sentinel-As-Code pipeline deploys. When you scaffold a new piece of content the toolkit copies the matching template into your repository, replaces its placeholder tokens, and writes it to the folder the pipeline expects.
 
-Every template is authored as **commented YAML**, so each field is documented inline as you edit it. That is the authoring format only. The toolkit writes most content to disk as YAML, but three content types (Summary Rule, Automation Rule, and Watchlist) are stored as JSON in the repository, so the toolkit converts those from YAML to JSON automatically at the point it scaffolds them. See [YAML on disk versus JSON on disk](#yaml-on-disk-versus-json-on-disk) below.
+Every template is authored as **commented YAML**, so each field is documented inline as you edit it. The scaffolders write the commented YAML template and ask where to save it. Most content deploys as YAML, but three content types (Summary Rule, Automation Rule, and Watchlist) are stored as JSON in the repository. Those are authored as YAML too, then converted with the explicit **Convert Content YAML to JSON** command, which writes the `.json` file beside the YAML. See [YAML on disk versus JSON on disk](#yaml-on-disk-versus-json-on-disk) below.
 
 The toolkit **authors and validates** content. It does **not** deploy. Deployment is the job of the Sentinel-As-Code pipeline. A template is a correct starting point for the pipeline's on-disk contract, not a deployment step.
 
@@ -24,18 +24,18 @@ Each content type has a dedicated schema and authoring guide. The templates are 
 
 ## The bundled templates
 
-There are eight templates. Each scaffolds one content type, targets a fixed folder under `Content/`, and is written in the format the pipeline reads from that folder.
+There are eight templates. Each scaffolds one content type, targets a fixed folder under `Content/`, and is authored as commented YAML. The scaffolder asks where to save it.
 
-| Template | Content type and repository folder | On-disk format | Conversion on scaffold |
+| Template | Content type and repository folder | Authored as | Deployed as |
 | --- | --- | --- | --- |
-| Standard Rule | Scheduled analytics rule, [`Content/AnalyticalRules/`](../../Content/AnalyticalRules) | YAML | Not required |
-| NRT Rule | Near-Real-Time analytics rule, [`Content/AnalyticalRules/`](../../Content/AnalyticalRules) | YAML | Not required |
-| Custom Detection | Defender XDR detection, [`Content/DefenderCustomDetections/`](../../Content/DefenderCustomDetections) | YAML | Not required |
-| Hunting Query | Hunting query, [`Content/HuntingQueries/`](../../Content/HuntingQueries) | YAML | Not required |
-| Parser | KQL parser / saved function, [`Content/Parsers/`](../../Content/Parsers) | YAML | Not required |
-| Summary Rule | Summary rule, [`Content/SummaryRules/`](../../Content/SummaryRules) | **JSON** | **Converted to JSON** |
-| Automation Rule | Automation rule, [`Content/AutomationRules/`](../../Content/AutomationRules) | **JSON** | **Converted to JSON** |
-| Watchlist | Watchlist metadata, `Content/Watchlists/<alias>/watchlist.json` | **JSON** | **Converted to JSON** |
+| Standard Rule | Scheduled analytics rule, [`Content/AnalyticalRules/`](../../Content/AnalyticalRules) | YAML | YAML |
+| NRT Rule | Near-Real-Time analytics rule, [`Content/AnalyticalRules/`](../../Content/AnalyticalRules) | YAML | YAML |
+| Custom Detection | Defender XDR detection, [`Content/DefenderCustomDetections/`](../../Content/DefenderCustomDetections) | YAML | YAML |
+| Hunting Query | Hunting query, [`Content/HuntingQueries/`](../../Content/HuntingQueries) | YAML | YAML |
+| Parser | KQL parser / saved function, [`Content/Parsers/`](../../Content/Parsers) | YAML | YAML |
+| Summary Rule | Summary rule, [`Content/SummaryRules/`](../../Content/SummaryRules) | YAML | **JSON** (via Convert Content YAML to JSON) |
+| Automation Rule | Automation rule, [`Content/AutomationRules/`](../../Content/AutomationRules) | YAML | **JSON** (via Convert Content YAML to JSON) |
+| Watchlist | Watchlist metadata, `Content/Watchlists/<alias>/watchlist.yaml` | YAML | **JSON** (`watchlist.json`, via Convert Content YAML to JSON) |
 
 ### What each template scaffolds
 
@@ -62,9 +62,9 @@ Three content types must be **JSON on disk** for the pipeline to read them:
 - **Automation Rule** goes to `Content/AutomationRules/<name>.json`
 - **Watchlist** goes to `Content/Watchlists/<alias>/watchlist.json` (plus its `data.csv` or `data.tsv`)
 
-For these three, the template is still authored as commented YAML, purely so the fields can be documented inline. When you scaffold one, the toolkit converts the YAML to JSON automatically and writes the JSON file. You commit the generated JSON, not the YAML. The comments do not survive the conversion, which is expected, because JSON has no comment syntax.
+For these three, the template is still authored as commented YAML, purely so the fields can be documented inline. There is no automatic conversion on scaffold. You author the YAML (guided by its inline comments), then run **Convert Content YAML to JSON** on the file, which writes the `.json` beside it. You commit the generated JSON, not the YAML. The comments do not survive the conversion, which is expected, because JSON has no comment syntax.
 
-Every other template (Standard Rule, NRT Rule, Custom Detection, Hunting Query, and Parser) is written as YAML and needs no conversion.
+Every other template (Standard Rule, NRT Rule, Custom Detection, Hunting Query, and Parser) is written as YAML and deploys as YAML, so no conversion is needed.
 
 This split is also reflected in the toolkit's schema binding: the Summary Rule, Automation Rule, and Watchlist schemas validate `*.json` files under their folders, while the analytics-rule, hunting-query, parser, and Defender schemas validate `*.yaml` / `*.yml` files.
 


### PR DESCRIPTION
## Summary

Bring `Docs/Toolkit/` and the affected `Docs/Content/` pages into line with the Sentinel-As-Code Toolkit's YAML-first authoring rework. Documentation only, no behavioural change.

## Why is this change needed?

The Toolkit changed how content is authored. Previously the three content types the pipeline stores as JSON (summary rules, automation rules, watchlists) were described as being "converted to JSON automatically when scaffolded". That is no longer true: every content type is now scaffolded as commented YAML, and those three are converted with a new explicit `Convert Content YAML to JSON` command. The docs still described the old behaviour and an outdated command count, so anyone following them would look for auto-conversion that no longer happens and miss the new command.

## What does this change do?

Targeted edits across seven documentation files to match current Toolkit behaviour:

- `Docs/Toolkit/Commands.md`: command count 25 to 26; adds the `Convert Content YAML to JSON` row and its editor/explorer context-menu entries; reworks the New Summary Rule, New Automation Rule, Create Watchlist from CSV, and New Content descriptions for the save-location-prompt, YAML-first flow.
- `Docs/Toolkit/Templates.md`: replaces the "Conversion on scaffold" column with "Authored as / Deployed as", and rewrites the YAML-versus-JSON section to describe the explicit convert step rather than auto-conversion.
- `Docs/Toolkit/README.md` and `Docs/Toolkit/Schemas-and-Validation.md`: drop the stale "converted to JSON on scaffold" claim and name the new command.
- `Docs/Content/Summary-Rules.md`, `Automation-Rules.md`, `Watchlists.md`: correct the same wording; Create Watchlist from CSV now scaffolds `watchlist.yaml` plus its data file, converted before deploy.

The deploy contract is unchanged: the pipeline still stores `watchlist.json` and the summary/automation JSON, and the schema bindings still validate the generated `.json`.

## What does this fix or affect?

No behavioural change. Documentation only. Corrects stale Toolkit authoring guidance in `Docs/Toolkit/` and three `Docs/Content/` pages.

## Type of change

- [ ] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [x] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [ ] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Files changed (high level)

- `Docs/Toolkit/Commands.md` - 26 commands, new Convert Content YAML to JSON entry, YAML-first scaffolding descriptions
- `Docs/Toolkit/Templates.md` - Authored as / Deployed as columns, explicit-convert narrative
- `Docs/Toolkit/README.md`, `Docs/Toolkit/Schemas-and-Validation.md` - remove auto-convert claim, name the new command
- `Docs/Content/Summary-Rules.md`, `Docs/Content/Automation-Rules.md`, `Docs/Content/Watchlists.md` - same correction, watchlist.yaml authoring flow

## Testing

Documentation only, so no runtime tests apply. Verified with the repository link checker (0 broken or case-mismatched relative links across the changed pages) and the house-style check (0 em-dashes introduced). Claims cross-checked against the Toolkit `README.md` and `package.json` (command ids, titles, and the 26-command count).

## Related

Follows the 26.07.2 documentation overhaul (#33), which introduced `Docs/Toolkit/`. Companion change slims the Toolkit repository README to point at these pages as the single source of truth.
