### PR TITLE
chore(repo): ignore local toolkit connectors file and Demo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ Tools/Export-Playbooks.ps1
 # Sentinel documenter output — contains tenant configuration; never commit.
 # Delivered via the workflow's private GitHub Actions artefact instead.
 SecurityDocs/
+.sentinel-connectors.json
+Demo


### PR DESCRIPTION
## Summary

Add two workspace-local paths to `.gitignore` so they are never accidentally committed.

## Why is this change needed?

Both files are local, machine or workspace specific, and have no place in the deployable content tree:

- `.sentinel-connectors.json` is written by the Sentinel as Code Toolkit when you populate a rule's required data connectors; it holds per-workspace custom-connector registrations.
- `Demo` is a local scratch directory used for demonstrations.

Without these entries they show up as untracked files on every `git status` and risk being staged by a broad `git add`.

## What does this change do?

Appends `.sentinel-connectors.json` and `Demo` to `.gitignore`, and terminates the file with a trailing newline.

## What does this fix or affect?

No behavioural change. Repository hygiene only. No tracked files are removed; the two paths are simply ignored going forward.

## Type of change

- [ ] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [ ] docs - documentation only
- [ ] test - Pester / schema test changes
- [x] chore - dependency bump, version pin, file rename
- [ ] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Testing

Not applicable. `.gitignore` change only. Confirmed the two paths are now ignored (`git status` no longer lists them) and that no previously tracked file is affected.
