### PR TITLE
feat(promptbooks): add Sentinel MCP prompt books for GitHub Copilot

### DIFF
--- a/Content/PromptBooks/AgentCreation/build-triage-agent.prompt.md
+++ b/Content/PromptBooks/AgentCreation/build-triage-agent.prompt.md
@@ -1,0 +1,81 @@
+---
+name: build-triage-agent
+description: Describe an agent in English and walk it through to a deployable Security Copilot definition.
+argument-hint: <what the agent should do>
+agent: agent
+---
+
+# Build a Security Copilot agent
+
+**Demonstrates:** the full agent-creation chain - `search_for_tools`,
+`start_agent_creation`, `compose_agent`, `get_evaluation`, `deploy_agent`.
+
+The story is that SOC engineers spend weeks hand-building playbooks. This beat compresses
+that to a conversation. Budget ten minutes; it is genuinely iterative and rushing it
+undersells the point.
+
+## Prerequisites
+
+- Agent creation collection connected
+  (`https://sentinel.microsoft.com/mcp/security-copilot-agent-creation`)
+- **Microsoft Security Copilot** provisioned. This collection needs it, unlike the other two.
+- Decide beforehand whether you will actually deploy, and to `User` or `Workspace` scope.
+
+## Prompt
+
+```text
+I want to build a Security Copilot agent that does this:
+
+${input:intent}
+
+Work through it properly:
+1. Search Security Copilot for tools, skills and agents that could serve this intent. Show
+   me what you found and which ones you plan to use.
+2. Start a new agent creation session with my problem statement.
+3. Compose the agent definition YAML.
+4. Retrieve the evaluation and show me the result.
+
+Do NOT deploy anything yet. Show me the YAML and stop.
+
+If you need decisions from me - trigger conditions, output format, which data sources -
+ask rather than assuming. I would rather answer three questions than review a wrong agent.
+```
+
+## Follow-ups
+
+```text
+Walk me through that YAML section by section. What does each part actually do at runtime?
+```
+
+```text
+Revise it: ${input:revision}. Keep the same session and edit the existing definition
+rather than starting over.
+```
+
+```text
+What would this agent do badly? Give me the failure modes before I deploy it, not after.
+```
+
+```text
+Deploy it to User scope. The skillset name must exactly match the Name under Descriptor
+in the definition YAML - confirm they match before you deploy.
+```
+
+## What good looks like
+
+- The model asks clarifying questions on the first pass. An agent composed with no
+  questions asked is usually an agent built on assumptions.
+- Readable YAML with a clear descriptor, tool list and instructions.
+- The failure-modes follow-up should produce real ones. If it says the agent is fine, push
+  harder - that is the reviewer instinct you want to demonstrate.
+
+## Demo notes
+
+- Pass `compose_agent` the session ID from `start_agent_creation`, not the one from
+  `search_for_tools`. They are different sessions and mixing them is the documented
+  mistake.
+- Deploying is a real change to your Security Copilot workspace. Use `User` scope for a
+  demo unless you have decided otherwise.
+- If you have an existing agent YAML, add it to the chat context and the compose step will
+  edit it rather than generating from scratch. That is a better demo for an audience that
+  already has agents.

--- a/Content/PromptBooks/AgentCreation/post-incident-report-agent.prompt.md
+++ b/Content/PromptBooks/AgentCreation/post-incident-report-agent.prompt.md
@@ -1,0 +1,66 @@
+---
+name: post-incident-report-agent
+description: Microsoft's own headline agent-creation scenario - a cross-product post-incident report agent.
+argument-hint: (no arguments)
+agent: agent
+---
+
+# Post-incident report agent
+
+**Demonstrates:** agent creation on the scenario Microsoft uses as its own example, so it
+is the one most likely to compose cleanly on stage. Use this when you want the beat to
+work rather than to explore.
+
+Run [build-triage-agent](build-triage-agent.prompt.md) first if you want to show the
+iterative conversation; run this one if you want the polished result.
+
+## Prerequisites
+
+- Agent creation collection connected
+- Microsoft Security Copilot provisioned
+- Ideally Defender, Purview and Sentinel incidents present, since the agent spans all three
+
+## Prompt
+
+```text
+Create an agent that generates a comprehensive post-incident report from Microsoft
+Defender, Microsoft Purview, and Microsoft Sentinel incidents; aggregates incident
+summaries, detailed insights, entities, and alerts; and provides actionable remediation
+steps.
+
+Search for the relevant tools first, then start the session and compose the definition.
+Show me the evaluation result.
+
+Stop before deploying.
+```
+
+## Follow-ups
+
+```text
+Add a section to the report that names the detection gap: what would have caught this
+earlier, and did we have the data to catch it?
+```
+
+```text
+Constrain the output to two pages. A post-incident report nobody reads has no value.
+```
+
+```text
+Who is the audience for this report - analyst, SOC manager, or exec? Rewrite the
+instructions so it is unambiguously written for a SOC manager.
+```
+
+## What good looks like
+
+- Tool discovery finds Defender, Purview and Sentinel incident skills.
+- A definition with distinct sections for summary, entities, alerts and remediation.
+- The detection-gap follow-up is the one worth keeping. It turns a reporting agent into a
+  feedback loop, and it is the natural bridge to
+  [detection-gap-analysis](../SentinelAsCode/detection-gap-analysis.prompt.md).
+
+## Demo notes
+
+- Verbatim from Microsoft's documentation, so if this one fails to compose you have an
+  environment problem rather than a prompt problem. Useful as a diagnostic.
+- The two-page constraint gets a laugh from anyone who has read a real post-incident
+  report. Keep it.

--- a/Content/PromptBooks/DataExploration/analyze-url-entity.prompt.md
+++ b/Content/PromptBooks/DataExploration/analyze-url-entity.prompt.md
@@ -1,0 +1,72 @@
+---
+name: analyze-url-entity
+description: Bulk URL and domain verdicts from a threat report - IOC triage without leaving the editor.
+argument-hint: <URL or domain> <workspace ID>
+agent: agent
+---
+
+# Analyse a URL entity
+
+**Demonstrates:** `analyze_url_entity` reasoning over Microsoft threat intelligence, your
+own TIP indicators, your watchlists, and actual URL activity in your organisation - in one
+call.
+
+Pairs well with a real threat report open on screen.
+
+## Prerequisites
+
+- Data exploration collection connected
+- **Security Copilot Contributor** role (consumes SCUs)
+- Best with `EmailUrlInfo`, `UrlClickEvents`, `ThreatIntelIndicators`, `Watchlist` and
+  `DeviceNetworkEvents` in the lake. It still returns a verdict without them, with a
+  disclaimer naming what was missing.
+
+## Prompt
+
+```text
+Analyse the following URL or domain in workspace ${input:workspaceId}, over the last
+seven days:
+
+${input:url}
+
+Start the analysis and poll for the result until it completes.
+
+Render the results as returned exactly from the tool.
+
+Then tell me one thing the tool does not: has anyone in my organisation actually
+interacted with this, and if so, who and when?
+```
+
+## Follow-ups (the bulk beat)
+
+```text
+Here are the URL IOCs from a threat analytics report:
+
+${input:iocList}
+
+Analyse each one and give me a single table: indicator, verdict, whether we have seen it
+in our own data, and first and last seen if we have.
+
+Run no more than five analyses at a time so we do not hit preview thresholds.
+```
+
+```text
+For any indicator with organisational activity, pivot into DeviceNetworkEvents and tell me
+which devices and users touched it, and whether the connection succeeded.
+```
+
+## What good looks like
+
+- A verdict grounded in both Microsoft TI and your own telemetry, clearly separated.
+- On the bulk follow-up, a clean table rather than five walls of prose.
+- Honest "not seen in your environment" answers. A tool that finds something everywhere
+  is not a tool you would trust.
+
+## Demo notes
+
+- The five-at-a-time instruction is not decoration. Running the whole IOC list
+  concurrently is the documented way to hit latency and threshold problems.
+- Use IOCs you know are clean as well as ones you know are bad. A demo where everything
+  comes back malicious teaches the audience nothing about the verdict quality.
+- The cross-reference into `DeviceNetworkEvents` is the same retro-hunt idea as
+  [retro-hunt-ioc-sweep](retro-hunt-ioc-sweep.prompt.md), just scoped to one indicator.

--- a/Content/PromptBooks/DataExploration/analyze-user-entity.prompt.md
+++ b/Content/PromptBooks/DataExploration/analyze-user-entity.prompt.md
@@ -1,0 +1,68 @@
+---
+name: analyze-user-entity
+description: One-click user verdict from the entity analyzer - the "is this account compromised?" beat.
+argument-hint: <Entra object ID> <workspace ID>
+agent: agent
+---
+
+# Analyse a user entity
+
+**Demonstrates:** `analyze_user_entity` plus `get_entity_analysis`. This is the tool that
+replaces twenty minutes of manual context gathering with a single call, and it is the
+easiest beat to land with a SOC audience.
+
+## Prerequisites
+
+- Data exploration collection connected
+- **Security Copilot Contributor** role. This tool consumes Security Compute Units (SCUs),
+  unlike the rest of the data exploration collection.
+- Required tables in the lake: `AlertEvidence`, `SigninLogs`, `CloudAppEvents`,
+  `IdentityInfo`. The tool errors and names what is missing if any are absent.
+- Better with `AADNonInteractiveUserSignInLogs` and `BehaviorAnalytics`, but works without.
+
+## Prompt
+
+```text
+Analyse the user with Microsoft Entra object ID ${input:objectId} in workspace
+${input:workspaceId}.
+
+Use an analysis window of the last seven days.
+
+Start the analysis, then poll for the result until it completes. If the first poll times
+out, poll again rather than giving up.
+
+Render the results as returned exactly from the tool. Do not summarise, re-rank or
+reformat the analyzer's verdict.
+```
+
+## Follow-ups
+
+```text
+Now, in your own words, tell me what a tier 1 analyst should do in the next ten minutes
+based on that verdict. Be specific about the action, not the theory.
+```
+
+```text
+Which single piece of evidence in that analysis is doing the most work? If it turned out
+to be wrong, would the verdict change?
+```
+
+## What good looks like
+
+- A verdict with supporting insights: authentication patterns, behavioural anomalies,
+  organisational activity.
+- The raw analyzer output, not a paraphrase. If the model summarises anyway, that is the
+  cue to point at the `render the results as returned exactly from the tool` line.
+- The analysis takes a couple of minutes. Talk over it.
+
+## Demo notes
+
+- **Entra object ID, not UPN.** On-premises-only Active Directory users are not supported.
+- **Seven days is the maximum window.** Longer windows are rejected; the cap exists to
+  protect accuracy.
+- Run at most five analyses concurrently. Beyond that, latency climbs and you risk hitting
+  preview thresholds mid-demo.
+- Have the object ID on your clipboard before you start. Hunting for it live kills the
+  pace, and this is a prompt where the pause is already long enough.
+- This is the only data-exploration prompt in the book that costs SCUs. Worth saying out
+  loud if cost governance is in the room.

--- a/Content/PromptBooks/DataExploration/analyze-user-entity.prompt.md
+++ b/Content/PromptBooks/DataExploration/analyze-user-entity.prompt.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-user-entity
-description: One-click user verdict from the entity analyzer - the "is this account compromised?" beat.
+description: One-click user verdict from the entity analyser - the "is this account compromised?" beat.
 argument-hint: <Entra object ID> <workspace ID>
 agent: agent
 ---
@@ -32,7 +32,7 @@ Start the analysis, then poll for the result until it completes. If the first po
 out, poll again rather than giving up.
 
 Render the results as returned exactly from the tool. Do not summarise, re-rank or
-reformat the analyzer's verdict.
+reformat the analyser's verdict.
 ```
 
 ## Follow-ups
@@ -51,7 +51,7 @@ to be wrong, would the verdict change?
 
 - A verdict with supporting insights: authentication patterns, behavioural anomalies,
   organisational activity.
-- The raw analyzer output, not a paraphrase. If the model summarises anyway, that is the
+- The raw analyser output, not a paraphrase. If the model summarises anyway, that is the
   cue to point at the `render the results as returned exactly from the tool` line.
 - The analysis takes a couple of minutes. Talk over it.
 

--- a/Content/PromptBooks/DataExploration/exposure-blast-radius.prompt.md
+++ b/Content/PromptBooks/DataExploration/exposure-blast-radius.prompt.md
@@ -1,0 +1,75 @@
+---
+name: exposure-blast-radius
+description: Graph tools - blast radius, attack paths and exposure perimeter in natural language.
+argument-hint: <entity name, e.g. a device or critical asset>
+agent: agent
+---
+
+# Exposure and blast radius
+
+**Demonstrates:** the graph tools (`find_blastradius`, `find_walkable_paths`,
+`find_exposure_perimeter`, `find_nodes`, `get_graph_context`). This is the "if this box
+falls, what else falls" question, asked without writing a single graph query.
+
+> Preview. Microsoft may change these tools substantially before release, and using them
+> invokes the graph meter. Say both out loud if cost or stability is in the room.
+
+## Prerequisites
+
+- Data exploration collection connected
+- Data lake onboarded to the **Defender portal** (graph tools require it)
+- At least read-only access in Microsoft Security Exposure Management
+- Critical assets classified, otherwise blast radius has nothing to aim at
+
+## Prompt
+
+```text
+First, get the graph context so you know which node labels and properties are valid in my
+graph. Show me the labels you can work with.
+
+Then, in my graph: what is the blast radius of ${input:entity} if it were compromised?
+
+For each propagation path you find:
+- the full hop-by-hop path
+- what makes each hop traversable (credential, permission, network reachability)
+- which critical asset it terminates at
+- the single change that would break the path
+
+Rank the paths by how much damage they enable, not by how many hops they are.
+```
+
+## Follow-ups
+
+```text
+In my graph, list all walkable paths from ${input:entity} to my critical assets. Where a
+path exists, tell me whether it is a design decision or an accident.
+```
+
+```text
+In my graph, what is the exposure perimeter of my critical SQL servers? Show me the
+incoming connections, limited to paths of three hops or fewer.
+```
+
+```text
+Of everything you have shown me, what is the one change that removes the most paths? I
+want the highest-leverage fix, not the longest list.
+```
+
+## What good looks like
+
+- `get_graph_context` runs first. Without it the model guesses at labels and the later
+  calls return nothing.
+- Paths with named intermediate nodes, not a count.
+- The "one change" answer should be specific and actionable. A generic "apply least
+  privilege" means the graph data is too thin to be interesting.
+
+## Demo notes
+
+- **Say `in my graph`** in every prompt. It is the documented way to scope these tools to
+  the graph rather than the lake, and it is the difference between a good answer and a
+  confused one.
+- **Identity lookups do not accept UPNs.** Use the display name or object ID.
+- **Put the entity type before the name** when you specify one, for example
+  `device zava-fin-01` rather than `zava-fin-01 device`.
+- Graph tools invoke the graph meter. Unlike the rest of this collection, running them
+  costs money. Keep the demo tight.

--- a/Content/PromptBooks/DataExploration/lake-orientation.prompt.md
+++ b/Content/PromptBooks/DataExploration/lake-orientation.prompt.md
@@ -1,0 +1,67 @@
+---
+name: lake-orientation
+description: Opening demo beat - list data lake workspaces, then discover which tables actually hold the signal you need.
+argument-hint: <what you want to find, e.g. "identity risk and sign-in anomalies">
+agent: agent
+---
+
+# Lake orientation
+
+**Demonstrates:** `list_sentinel_workspaces` then `search_tables`. The point of this beat
+is that nobody has to know the schema any more - you describe the signal in English and
+the model finds the tables.
+
+**Run this first.** Every other data-exploration prompt in this book assumes you already
+know your workspace ID.
+
+## Prerequisites
+
+- Data exploration collection connected (`https://sentinel.microsoft.com/mcp/data-exploration`)
+- Security Reader, Security Operator or Security Administrator
+- Workspace onboarded to the Microsoft Sentinel data lake
+
+## Prompt
+
+```text
+List every Microsoft Sentinel data lake workspace I have access to, with the workspace
+name and ID for each.
+
+Then, for the workspace I am most likely to be demoing against, search the table catalogue
+for tables relevant to: ${input:signal:identity risk and sign-in anomalies}
+
+For each table you find, give me:
+- the table name
+- one sentence on what it holds
+- the three or four columns I would actually pivot on
+
+Do not run any queries yet. Just show me the map.
+```
+
+## Follow-ups
+
+```text
+Now show me the full schema for the two tables you rated most useful, and tell me which
+one is the better starting point for a hunt and why.
+```
+
+```text
+Which of those tables are lake-tier only, and which are also in the analytics tier? If you
+cannot tell from the catalogue, say so rather than guessing.
+```
+
+## What good looks like
+
+- A list of workspaces with real IDs (not placeholders).
+- Four to eight tables, typically including `SigninLogs`, `AADUserRiskEvents`,
+  `BehaviorAnalytics` and `AADNonInteractiveUserSignInLogs` for the default input.
+- No KQL executed. If the model jumps straight to `query_lake`, that is a talking point
+  about tool scoping, not a failure.
+
+## Demo notes
+
+- If `list_sentinel_workspaces` returns nothing useful, or you need the system tables
+  database, add `Use 'default' as the workspaceId.` to the prompt.
+- Note the workspace ID out loud and paste it into later prompts. The documented failure
+  mode is tools silently picking a different workspace between turns.
+- Ask the audience to name a signal and re-run the search live. It holds up better than
+  the scripted input and takes about fifteen seconds.

--- a/Content/PromptBooks/DataExploration/retro-hunt-ioc-sweep.prompt.md
+++ b/Content/PromptBooks/DataExploration/retro-hunt-ioc-sweep.prompt.md
@@ -1,0 +1,82 @@
+---
+name: retro-hunt-ioc-sweep
+description: Sweep an IOC set across the full lake history - the retention story that the analytics tier cannot tell.
+argument-hint: <workspace ID>
+agent: agent
+---
+
+# Retro-hunt IOC sweep
+
+**Demonstrates:** the data lake's actual differentiator. The analytics tier is cost-bound
+to roughly ninety days. The lake holds up to twelve years. A fresh threat report drops and
+you can ask "have we ever seen this?" instead of "have we seen this recently?".
+
+This is the conversational twin of
+[`demo13_retrohunt_ioc_sweep.ipynb`](../../SparkNotebooks/demos/demo13_retrohunt_ioc_sweep.ipynb).
+Run the notebook when you want to show the engineering; run this when you want to show the
+speed.
+
+## Prerequisites
+
+- Data exploration collection connected
+- `DeviceNetworkEvents`, `DeviceFileEvents` or `DeviceProcessEvents` in the lake
+
+## Prompt
+
+```text
+Using workspace ID ${input:workspaceId}, sweep the following indicators across the FULL
+history available in the data lake. Do not restrict to the last 30 or 90 days - the whole
+point of this exercise is the long tail.
+
+File hashes (SHA256):
+${input:hashes}
+
+IP addresses:
+${input:ips}
+
+Domains or URLs:
+${input:domains}
+
+For every indicator that hits, give me:
+- indicator and type
+- first seen and last seen (full timestamps)
+- total hit count
+- how many distinct devices
+- which table it came from
+
+Sort by first seen, oldest first. Explicitly list the indicators that did NOT hit - a
+clean sweep is a result, not an empty response.
+
+Before you query, check which of the Device tables actually exist in this workspace and
+tell me which ones you are sweeping.
+```
+
+## Follow-ups
+
+```text
+Take the indicator with the earliest first-seen date. Reconstruct what happened on that
+device around that timestamp - processes, network, logons - and tell me whether this was
+the initial foothold.
+```
+
+```text
+How far back does our data actually go for each of these tables? If an indicator shows no
+hits, I want to know whether that means "clean" or "we have no data from that period".
+```
+
+## What good looks like
+
+- The model checks table availability before sweeping, rather than assuming.
+- Explicit no-hit reporting. The most common demo failure is a confident-sounding empty
+  response that the audience reads as "clean".
+- First-seen dates meaningfully older than ninety days. If everything is recent, the
+  retention story does not land and you should pick different indicators.
+
+## Demo notes
+
+- The last follow-up is the honest one and it is worth keeping. "No hits" and "no data"
+  are different answers, and an audience that has been burned by a SIEM will ask.
+- Keep the indicator list short, five to ten. A long list makes the sweep slow without
+  making the point any better.
+- If you have no known-bad indicators, use ones from a public threat report and expect a
+  clean sweep. Narrate it as the good outcome, because it is.

--- a/Content/PromptBooks/DataExploration/retro-hunt-ioc-sweep.prompt.md
+++ b/Content/PromptBooks/DataExploration/retro-hunt-ioc-sweep.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: retro-hunt-ioc-sweep
 description: Sweep an IOC set across the full lake history - the retention story that the analytics tier cannot tell.
-argument-hint: <workspace ID>
+argument-hint: <workspace ID> <hashes> <IPs> <domains>
 agent: agent
 ---
 

--- a/Content/PromptBooks/DataExploration/risky-user-hunt.prompt.md
+++ b/Content/PromptBooks/DataExploration/risky-user-hunt.prompt.md
@@ -1,0 +1,71 @@
+---
+name: risky-user-hunt
+description: The flagship beat - find the top at-risk users and have the model explain its reasoning and its KQL.
+argument-hint: <workspace ID> [number of users]
+agent: agent
+---
+
+# Risky user hunt
+
+**Demonstrates:** the full `search_tables` to `query_lake` orchestration loop. This is
+Microsoft's own headline sample prompt, expanded so the model has to show its working.
+
+The best moment in this demo is usually the model writing a KQL query, getting a semantic
+error back, and correcting itself without being asked. Let that happen on screen.
+
+## Prerequisites
+
+- Data exploration collection connected
+- Run [lake-orientation](lake-orientation.prompt.md) first to get your workspace ID
+
+## Prompt
+
+```text
+Using workspace ID ${input:workspaceId}, find the top ${input:count:3} users that are most
+at risk right now and explain why each one is at risk.
+
+Work in this order and narrate as you go:
+1. Search the table catalogue for tables covering user risk, sign-in behaviour and UEBA.
+2. Tell me which tables you picked and why before you query anything.
+3. Query the lake. Show me each KQL query you run.
+4. For every user you surface, give me: the UPN, the specific signals that make them
+   risky, when the behaviour started, and how confident you are.
+
+Rank by actual evidence, not by whatever risk score happens to exist. If two users are
+close, say so rather than inventing a tiebreak.
+```
+
+## Follow-ups
+
+```text
+Take the highest-risk user and pull their full sign-in timeline for the last seven days.
+I want the source IPs, countries, applications and the success or failure outcome for
+each. Flag anything that breaks their own established pattern.
+```
+
+```text
+Now show me what a false positive would look like here. Which of these signals would fire
+for a legitimate travelling executive, and what extra evidence would tell them apart?
+```
+
+```text
+Write the KQL you would schedule as a Sentinel analytics rule to catch this pattern going
+forward. Bound the time window and project a stable column set.
+```
+
+## What good looks like
+
+- The model searches the catalogue twice: once with narrow terms, then broader.
+- At least two `query_lake` calls, with the KQL visible in the response.
+- Named users with per-user evidence, not a generic risk-score table dump.
+- The last follow-up produces KQL you could realistically paste into
+  `Content/AnalyticalRules/` (see [hunt-to-analytical-rule](../SentinelAsCode/hunt-to-analytical-rule.prompt.md)).
+
+## Demo notes
+
+- A quiet tenant returns thin results. Check the last seven days have sign-in volume
+  before you present, and widen to thirty days in the prompt if not.
+- If the model stalls picking tools, start a fresh chat. The documented cause is
+  conversation context being favoured over tool invocation.
+- Keep the KQL error-and-self-correct moment. Do not re-run to get a clean take - the
+  recovery is the more interesting story.

--- a/Content/PromptBooks/DataExploration/signin-failure-triage.prompt.md
+++ b/Content/PromptBooks/DataExploration/signin-failure-triage.prompt.md
@@ -1,0 +1,65 @@
+---
+name: signin-failure-triage
+description: Turn a raw sign-in failure spike into a triaged summary - password spray, credential stuffing or a broken service account.
+argument-hint: <workspace ID> [hours to look back]
+agent: agent
+---
+
+# Sign-in failure triage
+
+**Demonstrates:** `query_lake` doing analyst work, not just retrieval. The model has to
+separate three failure shapes that look identical in a count-by-hour chart.
+
+## Prerequisites
+
+- Data exploration collection connected
+- `SigninLogs` in the lake (`AADNonInteractiveUserSignInLogs` improves it)
+
+## Prompt
+
+```text
+Using workspace ID ${input:workspaceId}, find sign-in failures in the last
+${input:hours:24} hours and give me a triaged summary.
+
+Do not just count failures. Classify what you find into these shapes and tell me which
+ones are actually present:
+- Password spray: many accounts, few attempts each, from a small set of source IPs
+- Credential stuffing: many accounts, many attempts, wide IP spread
+- A single account under brute force
+- A broken service account or expired credential looping
+
+For each shape you find, give me the accounts involved, the source IPs and countries, the
+Entra error codes, and whether any attempt eventually succeeded.
+
+Treat these error codes as success: 0, 50125, 50140, 70043, 70044. Everything else is a
+failure. A null error code is a failure, not a success.
+
+End with a single sentence: which of these, if any, would you wake someone up for?
+```
+
+## Follow-ups
+
+```text
+For any account that failed repeatedly and then succeeded, show me exactly what happened
+after the successful sign-in. Did the session do anything?
+```
+
+```text
+Compare this 24 hour window against the same window seven days ago. Is this volume actually
+abnormal for us, or is it Tuesday?
+```
+
+## What good looks like
+
+- A classification, not a table of counts. If you only get counts, push with
+  "which shape is this, and what evidence rules out the others?"
+- Correct handling of the success codes. The model should not report `50125`
+  (sign-in interrupted) as a failure.
+- The "would you wake someone up" answer should be a defensible no on most tenants.
+
+## Demo notes
+
+- The explicit error-code list is deliberate. Without it the model tends to treat
+  `ResultType != 0` as failure, which over-counts by a wide margin on real tenants.
+- The seven-day comparison follow-up is the one that lands with SOC managers. It shows
+  the lake making "is this normal for us" a one-line question.

--- a/Content/PromptBooks/README.md
+++ b/Content/PromptBooks/README.md
@@ -72,6 +72,16 @@ You can also add servers one at a time via **Ctrl+Shift+P** -> `MCP: Add Server`
 so Copilot finds these folders. Without it the `/slash-commands` will not appear and you
 will be copy-pasting instead - which still works, but is a worse demo.
 
+Both config files are deliberately plain JSON with no explanatory keys in them. A
+`_comment` key would be an unknown MCP server in `mcp.json` and an unknown setting in
+`settings.json`, and either can draw an editor warning. Everything you need to know about
+them is here instead.
+
+One shape to watch: if `settings.json` IntelliSense objects to `chat.promptFilesLocations`,
+open the setting in the Settings UI to see what your VS Code build expects. The key name is
+stable; the value shape has moved across releases, and Microsoft's own documentation
+describes the setting without ever showing its JSON.
+
 **3. Set chat to Agent mode.** MCP tools are only available in agent mode.
 
 **4. Verify.** Open Copilot Chat, click **Configure Tools**, and confirm the Sentinel
@@ -108,7 +118,7 @@ frontmatter alone and disable the collections you are not using in **Configure T
 | --- | --- | --- | --- |
 | Sentinel data lake | Required | - | - |
 | Defender portal onboarding | Graph tools only | Required | - |
-| Security Copilot | Entity analyzer only | - | Required |
+| Security Copilot | Entity analyser only | - | Required |
 | Minimum role | Security Reader | Your existing permissions | Security Copilot access |
 
 ## Writing your own
@@ -129,7 +139,7 @@ Four more that earn their place in a prompt:
 - **Name the workspace ID.** With several workspaces connected, tools will otherwise pick
   between them turn to turn.
 - **Say `in my graph`** for graph tools, or they answer from the lake instead.
-- **Say `render the results as returned exactly from the tool`** for the entity analyzer,
+- **Say `render the results as returned exactly from the tool`** for the entity analyser,
   or the client re-summarises a verdict that was already a summary.
 - **Say `Use 'default' as the workspaceId.`** to reach system tables, which have no
   workspace ID of their own.

--- a/Content/PromptBooks/README.md
+++ b/Content/PromptBooks/README.md
@@ -1,0 +1,144 @@
+# PromptBooks - Microsoft Sentinel MCP prompts for GitHub Copilot
+
+Runnable prompt books for the [Microsoft Sentinel MCP server](https://learn.microsoft.com/azure/sentinel/datalake/sentinel-mcp-overview),
+built for live demos in **VS Code + GitHub Copilot agent mode**.
+
+Each file is a VS Code [prompt file](https://code.visualstudio.com/docs/agent-customization/prompt-files):
+invoke it with `/<name>` in Copilot Chat, or just copy the prompt text out of it. Every
+book carries a primary prompt, follow-ups that build a narrative, a *what good looks like*
+section so you can tell live whether it worked, and demo notes covering the failure modes.
+
+## Documentation
+
+- **[Prompt Books](../../Docs/Content/Prompt-Books.md)** - full catalogue, the MCP tool
+  reference, prompt-writing guidance, running orders and troubleshooting.
+
+## Contents
+
+**Data exploration** - `https://sentinel.microsoft.com/mcp/data-exploration`
+
+| Prompt | Demonstrates | Cost |
+| --- | --- | --- |
+| [`lake-orientation`](DataExploration/lake-orientation.prompt.md) | `list_sentinel_workspaces`, `search_tables` - run this first | Free |
+| [`risky-user-hunt`](DataExploration/risky-user-hunt.prompt.md) | The full search-to-query loop, with self-correcting KQL | Free |
+| [`signin-failure-triage`](DataExploration/signin-failure-triage.prompt.md) | `query_lake` classifying spray vs stuffing vs broken service account | Free |
+| [`analyze-user-entity`](DataExploration/analyze-user-entity.prompt.md) | `analyze_user_entity` - one-click compromise verdict | **SCUs** |
+| [`analyze-url-entity`](DataExploration/analyze-url-entity.prompt.md) | `analyze_url_entity` - bulk IOC verdicts from a threat report | **SCUs** |
+| [`retro-hunt-ioc-sweep`](DataExploration/retro-hunt-ioc-sweep.prompt.md) | Full-history IOC sweep - the retention story | Free |
+| [`exposure-blast-radius`](DataExploration/exposure-blast-radius.prompt.md) | Graph tools - blast radius and attack paths | **Graph meter** |
+
+**Triage** - `https://sentinel.microsoft.com/mcp/triage`
+
+| Prompt | Demonstrates |
+| --- | --- |
+| [`incident-queue-triage`](Triage/incident-queue-triage.prompt.md) | `ListIncidents` - rank the queue and argue with the assigned severity |
+| [`incident-deep-dive`](Triage/incident-deep-dive.prompt.md) | Incident to alerts to evidence to a committed verdict |
+| [`file-hash-investigation`](Triage/file-hash-investigation.prompt.md) | The four Defender file tools, and the SHA-1 constraint |
+| [`device-investigation`](Triage/device-investigation.prompt.md) | Five portal tabs collapsed into one endpoint briefing |
+| [`user-investigation`](Triage/user-investigation.prompt.md) | Target, vector, cause or noise |
+| [`cve-exposure-sweep`](Triage/cve-exposure-sweep.prompt.md) | "Are we exposed to this CVE" - and is it being exploited |
+
+**Agent creation** - `https://sentinel.microsoft.com/mcp/security-copilot-agent-creation`
+
+| Prompt | Demonstrates |
+| --- | --- |
+| [`build-triage-agent`](AgentCreation/build-triage-agent.prompt.md) | The full `search_for_tools` to `deploy_agent` chain |
+| [`post-incident-report-agent`](AgentCreation/post-incident-report-agent.prompt.md) | Microsoft's own headline scenario - the reliable one |
+
+**Sentinel-As-Code** - MCP plus this repository
+
+| Prompt | Demonstrates |
+| --- | --- |
+| [`hunt-to-analytical-rule`](SentinelAsCode/hunt-to-analytical-rule.prompt.md) | Lake finding to committed rule YAML, with a 30-day fire count |
+| [`validate-rule-against-lake`](SentinelAsCode/validate-rule-against-lake.prompt.md) | Do a rule's tables and columns actually exist here? |
+| [`detection-gap-analysis`](SentinelAsCode/detection-gap-analysis.prompt.md) | What we detect vs what the lake holds, and where they disagree |
+
+## Setup
+
+**1. Add the MCP servers.** Copy [`mcp.json`](mcp.json) to `.vscode/mcp.json`:
+
+```bash
+cp Content/PromptBooks/mcp.json .vscode/mcp.json
+```
+
+`.vscode/` is git-ignored in this repo, which is why the template lives here. Reload VS
+Code, then sign in when prompted with an account holding at least **Security Reader**.
+
+You can also add servers one at a time via **Ctrl+Shift+P** -> `MCP: Add Server` ->
+**HTTP** -> paste the URL. Any server ID works; nothing in these prompt files depends on it.
+
+**2. Make the prompts discoverable.** Merge
+[`vscode-settings.snippet.json`](vscode-settings.snippet.json) into `.vscode/settings.json`
+so Copilot finds these folders. Without it the `/slash-commands` will not appear and you
+will be copy-pasting instead - which still works, but is a worse demo.
+
+**3. Set chat to Agent mode.** MCP tools are only available in agent mode.
+
+**4. Verify.** Open Copilot Chat, click **Configure Tools**, and confirm the Sentinel
+servers are listed with their tools.
+
+### Optional: scope tools per prompt
+
+None of these files pin a `tools:` list, deliberately. A prompt file that names an MCP
+server which is not registered yet produces
+`Unknown tool '<server>/*' will be ignored (promptValidator.unknownExtensionOrMcpServerReference)`
+in the editor, and a squiggle in every file is a poor way to start a demo. Without the
+key, the prompt simply uses whatever tools are enabled in chat.
+
+Once your servers are registered and you know their IDs, scoping is worth adding back.
+Microsoft's troubleshooting guidance is that models pick tools badly when too many
+semantically overlapping ones are enabled, and per-prompt scoping is the documented
+mitigation. Add one line to the frontmatter, matching your own server IDs:
+
+```yaml
+tools: ['sentinel-data-exploration/*']       # DataExploration/ and SentinelAsCode/
+tools: ['sentinel-triage/*']                 # Triage/
+tools: ['sentinel-agent-creation/*']         # AgentCreation/
+```
+
+The `SentinelAsCode/` prompts also touch the repo, so they want
+`['sentinel-data-exploration/*', 'search/codebase', 'edit/applyPatch', 'terminal/run']`.
+
+The cheaper alternative, and the one to use if you are presenting in an hour: leave the
+frontmatter alone and disable the collections you are not using in **Configure Tools**.
+
+## Prerequisites by collection
+
+| | Data exploration | Triage | Agent creation |
+| --- | --- | --- | --- |
+| Sentinel data lake | Required | - | - |
+| Defender portal onboarding | Graph tools only | Required | - |
+| Security Copilot | Entity analyzer only | - | Required |
+| Minimum role | Security Reader | Your existing permissions | Security Copilot access |
+
+## Writing your own
+
+Microsoft's guidance, and it holds up: **be specific**. Their own contrast is worth
+internalising -
+
+> `For user <UPN>, baseline their network, file, sign-in, and device events over 90 days
+> and compare with +/- 10 minutes to find anomalies or suspicious activities to help me
+> triage the severity and priority of this alert.`
+
+beats
+
+> `What is risky about <UPN>?`
+
+Four more that earn their place in a prompt:
+
+- **Name the workspace ID.** With several workspaces connected, tools will otherwise pick
+  between them turn to turn.
+- **Say `in my graph`** for graph tools, or they answer from the lake instead.
+- **Say `render the results as returned exactly from the tool`** for the entity analyzer,
+  or the client re-summarises a verdict that was already a summary.
+- **Say `Use 'default' as the workspaceId.`** to reach system tables, which have no
+  workspace ID of their own.
+
+## Notes
+
+- Prompt files are recognised in VS Code, Visual Studio and JetBrains. They are **not**
+  recognised on github.com or by Copilot CLI - see
+  [GitHub Copilot Setup](../../Docs/GitHub/GitHub-Copilot.md) for the full platform matrix.
+- These are demo scripts, not deployable Sentinel content. Nothing here is picked up by the
+  deploy pipelines.
+- Docs: https://learn.microsoft.com/azure/sentinel/datalake/sentinel-mcp-overview

--- a/Content/PromptBooks/SentinelAsCode/detection-gap-analysis.prompt.md
+++ b/Content/PromptBooks/SentinelAsCode/detection-gap-analysis.prompt.md
@@ -1,0 +1,80 @@
+---
+name: detection-gap-analysis
+description: Compare what this repo detects against what the lake actually shows - find the coverage you think you have.
+argument-hint: <workspace ID> [MITRE tactic to focus on]
+agent: agent
+---
+
+# Detection gap analysis
+
+**Demonstrates:** MCP reading your detection library and your telemetry together, and
+telling you where they disagree. The closing beat for a technical audience.
+
+Three kinds of gap, and they need different fixes:
+
+1. **Data you have, detection you do not** - the fixable gap
+2. **Detection you have, data you do not** - the false-confidence gap, and the dangerous one
+3. **Neither** - the honest gap, which is a roadmap item
+
+## Prerequisites
+
+- Data exploration collection connected
+- This repository open in VS Code
+
+## Prompt
+
+```text
+Compare this repository's detection coverage against what my data lake actually contains,
+for workspace ${input:workspaceId}.
+
+1. Read every rule under Content/AnalyticalRules/ and every query under
+   Content/HuntingQueries/. Build a picture of what tables and MITRE techniques we cover.
+
+2. Search my lake's table catalogue for what data I actually have.
+
+3. Produce three lists:
+   - Tables with meaningful data that NO rule or hunting query touches
+   - Rules or queries referencing tables that are absent or empty in my lake
+   - MITRE techniques with neither coverage nor the data to build it
+
+${input:focus}
+
+For the first list, rank by how much detection value the table would unlock, not by row
+count. A high-volume table nobody should alert on is not a gap.
+
+Be specific about what you could not determine, and why.
+```
+
+## Follow-ups
+
+```text
+Take the top three uncovered tables. For each, propose one concrete detection and show me
+the KQL. Query the lake first to confirm the pattern actually exists in my data.
+```
+
+```text
+For rules referencing absent tables: is the fix to onboard a connector, or to delete a
+rule that was never going to fire here? Give me a recommendation per rule, not a list of
+options.
+```
+
+```text
+Which single data source, if onboarded, would close the most technique gaps?
+```
+
+## What good looks like
+
+- Three genuinely distinct lists. Collapsing them into "gaps" loses the whole point.
+- The false-confidence list is the uncomfortable one and usually the most valuable.
+- The "single data source" answer should name one connector with a defensible reason.
+
+## Demo notes
+
+- The false-confidence gap is the finding that changes behaviour. A rule referencing a
+  table with no data is worse than no rule at all, because it appears on the coverage
+  dashboard as green.
+- Pairs with [`demo18_mitre_attack_coverage.ipynb`](../../SparkNotebooks/demos/demo18_mitre_attack_coverage.ipynb),
+  which renders the same idea as a tactic-by-technique heatmap. Run the notebook for the
+  picture, this prompt for the reasoning.
+- Use the `${input:focus}` argument to scope to one tactic when time is short. A full sweep
+  across the whole library takes a while and the audience stops reading.

--- a/Content/PromptBooks/SentinelAsCode/hunt-to-analytical-rule.prompt.md
+++ b/Content/PromptBooks/SentinelAsCode/hunt-to-analytical-rule.prompt.md
@@ -1,0 +1,89 @@
+---
+name: hunt-to-analytical-rule
+description: Turn a lake finding into a committed analytics rule - the beat that closes the loop back into this repo.
+argument-hint: <workspace ID> <what you found>
+agent: agent
+---
+
+# Hunt to analytical rule
+
+**Demonstrates:** the whole point of running these demos in *this* repo. Hunt in the lake
+with MCP, then commit the finding as version-controlled detection content. Ad-hoc hunt
+becomes standing coverage, in one conversation.
+
+Run this immediately after
+[risky-user-hunt](../DataExploration/risky-user-hunt.prompt.md) or
+[signin-failure-triage](../DataExploration/signin-failure-triage.prompt.md), while the
+finding is still on screen.
+
+## Prerequisites
+
+- Data exploration collection connected
+- This repository open in VS Code
+
+## Prompt
+
+```text
+I found this in the data lake (workspace ${input:workspaceId}):
+
+${input:finding}
+
+Turn it into an analytics rule for this repository.
+
+1. Validate it first. Query the lake to confirm the pattern is real, and tell me roughly
+   how many times it would have fired over the last 30 days. If that number is absurd, say
+   so and tighten the logic before we go any further.
+
+2. Read .github/instructions/analytical-rules.instructions.md and
+   .github/instructions/kql-queries.instructions.md so you follow this repo's schema
+   rather than a generic one.
+
+3. Look at two or three existing rules under Content/AnalyticalRules/ to match the house
+   style.
+
+4. Write the rule to Content/AnalyticalRules/<SourceFolder>/<RuleName>.yaml. Generate a
+   fresh GUID for the id. Pick the source folder from the primary data table.
+
+5. Regenerate the dependency manifest and run the schema tests:
+   ./Tools/Build-DependencyManifest.ps1 -Mode Generate
+   Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1
+   Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1
+
+Do not commit. Show me the rule and the test output.
+```
+
+## Follow-ups
+
+```text
+That fire count is too high. Tighten it without losing the true positives - and tell me
+explicitly what class of detection I am giving up.
+```
+
+```text
+Add entityMappings for every column that should become a Sentinel entity. Without those
+the alerts will not correlate into incidents properly.
+```
+
+```text
+Write the entity mappings and then query the lake to prove every mapped column is
+populated. A mapping to a mostly-null column is worse than no mapping.
+```
+
+## What good looks like
+
+- The 30-day fire count comes back *before* any YAML is written. A rule authored without
+  it is a rule nobody will keep enabled.
+- The YAML uses `enabled: true|false`, not `status:`, and PascalCase tactics. Those are
+  the two schema mistakes generic models make against this repo.
+- Both Pester test files pass.
+- The last follow-up catches null-heavy entity mappings, which is the same class of bug as
+  the null-key problem in the Spark notebooks.
+
+## Demo notes
+
+- This is the beat that differentiates a Sentinel-As-Code demo from a Sentinel MCP demo.
+  The finding does not evaporate when the chat window closes - it becomes a pull request.
+- If the audience is engineering-heavy, run `git diff` afterwards. A reviewable diff is a
+  more persuasive artefact than any chat transcript.
+- The fire-count validation step is what separates this from a rule generator. Keep it in
+  even when time is tight.

--- a/Content/PromptBooks/SentinelAsCode/validate-rule-against-lake.prompt.md
+++ b/Content/PromptBooks/SentinelAsCode/validate-rule-against-lake.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: validate-rule-against-lake
 description: Check a committed rule against real data - do its tables and columns exist, and would it ever fire?
-argument-hint: <path to a rule YAML>
+argument-hint: <path to a rule YAML> <workspace ID>
 agent: agent
 ---
 

--- a/Content/PromptBooks/SentinelAsCode/validate-rule-against-lake.prompt.md
+++ b/Content/PromptBooks/SentinelAsCode/validate-rule-against-lake.prompt.md
@@ -1,0 +1,75 @@
+---
+name: validate-rule-against-lake
+description: Check a committed rule against real data - do its tables and columns exist, and would it ever fire?
+argument-hint: <path to a rule YAML>
+agent: agent
+---
+
+# Validate a rule against the lake
+
+**Demonstrates:** MCP as a test harness. Schema tests prove a rule is well-formed. Only
+real data proves it would ever fire.
+
+Every repo accumulates rules referencing tables nobody onboarded and columns that were
+renamed two connector versions ago. This finds them.
+
+## Prerequisites
+
+- Data exploration collection connected
+- This repository open in VS Code
+
+## Prompt
+
+```text
+Read ${input:rulePath} and validate it against my actual data lake, workspace
+${input:workspaceId}.
+
+Check, in this order:
+1. Does every table the query references exist in my workspace? Use the table catalogue.
+2. Does every column the query references exist on those tables, with a compatible type?
+3. Run the rule's KQL against the lake over the last 30 days. How many times would it have
+   fired?
+4. For every column in entityMappings, what percentage of matching rows actually have a
+   value? A mapping to a mostly-null column will not correlate.
+
+Give me a verdict per check: pass, fail, or cannot determine. "Cannot determine" is a
+valid answer - do not guess to fill the table.
+
+If the query will not run as written, show me the error and the smallest change that fixes
+it.
+```
+
+## Follow-ups
+
+```text
+Do the same for every rule in Content/AnalyticalRules/${input:folder}/. One row per rule:
+tables exist, columns exist, 30-day fire count, verdict. Rank worst first.
+```
+
+```text
+For anything that failed, tell me whether the fix is to change the rule or to onboard a
+data source. Those go to different people.
+```
+
+```text
+Which of these rules has fired zero times in 30 days AND references a table with no data
+at all? That is the difference between a quiet rule and a dead one.
+```
+
+## What good looks like
+
+- Real fire counts, including zeros. A zero is information.
+- Honest "cannot determine" for anything the model could not check, particularly custom
+  tables and watchlist functions like `_GetWatchlist()`.
+- The last follow-up separating quiet rules from dead rules. Those need different fixes and
+  most coverage reviews conflate them.
+
+## Demo notes
+
+- Run the folder-wide sweep against a small folder first. `Content/AnalyticalRules/` as a
+  whole is a lot of rules and a long wait.
+- Rules using watchlist functions or parsers will often come back as "cannot determine".
+  That is correct behaviour, not a gap - the lake does not resolve saved functions the way
+  the analytics tier does.
+- Expect to find at least one broken rule. Every repo has one, and finding it live is a
+  better demo than a clean sweep.

--- a/Content/PromptBooks/Triage/cve-exposure-sweep.prompt.md
+++ b/Content/PromptBooks/Triage/cve-exposure-sweep.prompt.md
@@ -1,0 +1,67 @@
+---
+name: cve-exposure-sweep
+description: A CVE drops - work out exposure, prioritise patching, and check whether it is already being exploited here.
+argument-hint: <CVE ID, e.g. CVE-2024-49112>
+agent: agent
+---
+
+# CVE exposure sweep
+
+**Demonstrates:** `ListDefenderMachinesByVulnerability`,
+`ListDefenderVulnerabilitiesBySoftware` and `ListDefenderRemediationActivities`, tied
+together with hunting queries. The Tuesday-morning question: "we just got asked about this
+CVE, are we exposed?"
+
+## Prerequisites
+
+- Triage collection connected
+- Defender Vulnerability Management data flowing
+
+## Prompt
+
+```text
+${input:cve} has just been published and my leadership is asking about it.
+
+1. List every device in my tenant affected by it.
+2. For the affected devices, pull their details - risk score, exposure level, health.
+3. Check whether any remediation activity already covers this.
+
+Then give me a patch priority order. Do not just sort by device risk score - weight it by
+what the device actually is and who signs in to it.
+
+Finish with a two-sentence answer for a non-technical exec: are we exposed, and what are
+we doing about it?
+```
+
+## Follow-ups
+
+```text
+Look up the advanced hunting table schemas, then hunt for signs this CVE is actually being
+exploited in my environment, not just present. Tell me clearly which of those two you have
+evidence for.
+```
+
+```text
+For the top three devices in your patch order, list every other vulnerability on them. Is
+this CVE actually their biggest problem?
+```
+
+```text
+Which devices are affected but have no remediation activity at all? That is my gap list.
+```
+
+## What good looks like
+
+- A prioritised order with stated reasoning, not a risk-score sort.
+- A clear distinction between "vulnerable" and "being exploited". Conflating the two is
+  the mistake this prompt exists to avoid.
+- The gap list from the last follow-up is usually the most actionable output.
+
+## Demo notes
+
+- Pick a CVE you know is present. `ListDefenderMachinesByVulnerability` on an absent CVE
+  returns an empty list, which is a correct and completely flat demo.
+- The exec-summary sentence is worth keeping. It is the output most likely to survive
+  contact with a real incident.
+- Ties back to [`demo18_mitre_attack_coverage.ipynb`](../../SparkNotebooks/demos/demo18_mitre_attack_coverage.ipynb)
+  if you want to follow "are we exposed" with "do we detect it".

--- a/Content/PromptBooks/Triage/device-investigation.prompt.md
+++ b/Content/PromptBooks/Triage/device-investigation.prompt.md
@@ -1,0 +1,69 @@
+---
+name: device-investigation
+description: Everything known about one endpoint - health, alerts, users, vulnerabilities, remediation state.
+argument-hint: <device ID>
+agent: agent
+---
+
+# Device investigation
+
+**Demonstrates:** `GetDefenderMachine`, `GetDefenderMachineAlerts`,
+`GetDefenderMachineLoggedOnUsers`, `GetDefenderMachineVulnerabilities` and
+`ListDefenderRemediationActivities` assembled into a single endpoint picture.
+
+The manual version of this is five portal tabs. That contrast is the demo.
+
+## Prerequisites
+
+- Triage collection connected
+- A Defender for Endpoint device ID
+
+## Prompt
+
+```text
+Give me the complete picture of device ${input:deviceId}.
+
+Pull all of the following and present it as one briefing, not five tool dumps:
+- Device details: OS, health status, risk score, exposure level
+- Every security alert associated with it
+- Every account that has signed in to it
+- Discovered vulnerabilities with CVE IDs and severity
+- Any remediation tasks targeting it, and their status
+
+Then tell me:
+- Is this device currently compromised, previously compromised, or clean?
+- What is the highest-risk thing about it right now - and is that a vulnerability, an
+  alert, or a user?
+- What is the single next action?
+
+Where the risk score and the actual evidence disagree, say so.
+```
+
+## Follow-ups
+
+```text
+Take the highest-severity CVE on this device. Which other devices in my tenant are
+affected by it? I want the patch-priority picture, not just this one box.
+```
+
+```text
+For the accounts that signed in here, pull their related alerts. Is this device the
+problem, or is a user carrying the problem between devices?
+```
+
+## What good looks like
+
+- One briefing, not five sections of raw tool output. If you get the latter, the
+  "present it as one briefing" instruction needs to be firmer.
+- The risk-score-versus-evidence disagreement is usually the most interesting line in the
+  answer. A high exposure score driven entirely by unpatched software is a different
+  conversation from one driven by active alerts.
+- The device-versus-user follow-up reframes the investigation, and it is where lateral
+  movement usually shows up.
+
+## Demo notes
+
+- Pick a device with some history. A freshly imaged laptop produces an accurate and very
+  boring answer.
+- The CVE fan-out uses `ListDefenderMachinesByVulnerability` and is the natural handover
+  into [cve-exposure-sweep](cve-exposure-sweep.prompt.md) if you are running both.

--- a/Content/PromptBooks/Triage/file-hash-investigation.prompt.md
+++ b/Content/PromptBooks/Triage/file-hash-investigation.prompt.md
@@ -1,0 +1,69 @@
+---
+name: file-hash-investigation
+description: Full file verdict - reputation, prevalence, alerts and spread - with the SHA-1 gotcha handled up front.
+argument-hint: <SHA-1 hash>
+agent: agent
+---
+
+# File hash investigation
+
+**Demonstrates:** `GetDefenderFileInfo`, `GetDefenderFileStatistics`,
+`GetDefenderFileAlerts` and `GetDefenderFileRelatedMachines` chained on one indicator.
+
+**Use a SHA-1 hash.** The four file tools do not agree on hash types: `GetDefenderFileInfo`
+and `GetDefenderFileStatistics` accept SHA-1 or SHA-256, but `GetDefenderFileAlerts` and
+`GetDefenderFileRelatedMachines` accept **SHA-1 only**. MD5 works nowhere. Hand the model a
+SHA-256 and the chain half-completes, which is a confusing thing to debug on stage.
+
+## Prerequisites
+
+- Triage collection connected
+- A SHA-1 hash with real prevalence in your tenant
+
+## Prompt
+
+```text
+Investigate the file with SHA-1 hash ${input:sha1}.
+
+Chain these together and show me each result:
+1. File details - hashes, size, type, publisher, signer certificate, global prevalence,
+   first and last seen.
+2. Organisational prevalence - how many of my devices have seen it.
+3. Every alert this file has generated in my organisation, historical and active.
+4. Every device that encountered it.
+
+Then answer three questions directly:
+- Is this file malicious, and how confident are you?
+- Is it spreading, holding steady, or already contained?
+- What do I do in the next hour?
+
+If any tool rejects the hash, tell me which one and why rather than silently skipping it.
+```
+
+## Follow-ups
+
+```text
+For the devices that encountered this file, pull their alerts and logged-on users. Is
+there a common user, a common software build, or a common network segment?
+```
+
+```text
+Check whether this hash is already in our threat indicators. If it is not and you believe
+it should be, tell me what indicator action you would set and at what severity.
+```
+
+## What good looks like
+
+- All four tools complete. A partial chain almost always means a SHA-256 was supplied.
+- Global prevalence and organisational prevalence reported separately. A file that is
+  common worldwide and rare here is a very different story from the reverse.
+- A confidence statement, not a binary verdict.
+
+## Demo notes
+
+- Say the SHA-1 constraint out loud. It is a real API inconsistency, and audiences who
+  build automation care about it more than they care about the verdict.
+- A clean file makes a duller demo but a more honest one. Signed, prevalent, no alerts is
+  exactly what the tool should say about a legitimate binary.
+- If you need a SHA-1 from a SHA-256, the file-details tool resolves SHA-256 to SHA-1
+  internally - run that first and read the SHA-1 out of the result.

--- a/Content/PromptBooks/Triage/incident-deep-dive.prompt.md
+++ b/Content/PromptBooks/Triage/incident-deep-dive.prompt.md
@@ -1,0 +1,65 @@
+---
+name: incident-deep-dive
+description: Take one incident apart - alerts, evidence, entities - and reach a defensible verdict.
+argument-hint: <incident ID>
+agent: agent
+---
+
+# Incident deep dive
+
+**Demonstrates:** `GetIncidentById`, `ListAlerts`, `GetAlertByID` and the hunting tools
+chained into one investigation. Run this straight after
+[incident-queue-triage](incident-queue-triage.prompt.md) on whatever it ranked first.
+
+## Prerequisites
+
+- Triage collection connected
+- An incident ID worth investigating
+
+## Prompt
+
+```text
+Investigate incident ${input:incidentId} end to end.
+
+1. Pull the incident with its alert data.
+2. For every alert in it, pull the full alert detail including evidence entities.
+3. Build me a single timeline of what happened, in order, with timestamps.
+4. List every entity involved - users, devices, files, IPs, URLs - and say which ones are
+   confirmed malicious, which are suspicious, and which are almost certainly benign.
+5. Give me a verdict: true positive, false positive, or benign true positive. Commit to
+   one and justify it.
+
+If the evidence does not support a confident verdict, say what specific extra data you
+would need. Do not pad a weak conclusion.
+```
+
+## Follow-ups
+
+```text
+Look up the advanced hunting table schemas you need, then run a hunting query to find any
+other device or user that interacted with the entities from this incident in the last
+seven days. Has this spread?
+```
+
+```text
+Write the incident summary I would paste into the ticket. Analyst audience, no marketing
+language, under 200 words, and lead with the verdict.
+```
+
+```text
+If this is a true positive, what is the containment action and what is the blast radius of
+taking it? I want to know what breaks if we isolate that device.
+```
+
+## What good looks like
+
+- The model runs `FetchAdvancedHuntingTablesDetailedSchema` before writing hunting KQL.
+  Skipping that step is the documented cause of malformed queries.
+- A timeline with real timestamps, not "then the attacker moved laterally".
+- A committed verdict. Hedging across all three options is the failure mode to push back on.
+
+## Demo notes
+
+- The ticket-summary follow-up is the one non-technical stakeholders react to. Keep it in.
+- If the spread query returns nothing, that is a good outcome and worth narrating as
+  containment already holding, rather than skipping past it.

--- a/Content/PromptBooks/Triage/incident-queue-triage.prompt.md
+++ b/Content/PromptBooks/Triage/incident-queue-triage.prompt.md
@@ -1,0 +1,67 @@
+---
+name: incident-queue-triage
+description: Point the model at the incident queue and make it argue for what to work first.
+argument-hint: [number of incidents]
+agent: agent
+---
+
+# Incident queue triage
+
+**Demonstrates:** `ListIncidents` plus `GetIncidentById`. The opening beat for the triage
+collection, and the one that maps most directly onto what a tier 1 analyst does at 09:00.
+
+## Prerequisites
+
+- Triage collection connected (`https://sentinel.microsoft.com/mcp/triage`)
+- Microsoft Defender XDR, Defender for Endpoint, or Sentinel onboarded to the Defender portal
+- Your own tenant. Guest and delegated access are not supported by this collection.
+
+## Prompt
+
+```text
+List the last ${input:count:10} incidents in my tenant, newest first, and include the
+underlying alert data.
+
+Then triage them for me. Give me a ranked list, most urgent first, and for each incident:
+- incident ID and title
+- severity as assigned, and severity as YOU would assign it
+- the entities involved
+- one sentence on what is actually happening
+- work it now / work it today / close it
+
+Where your severity differs from the assigned severity, say why. That disagreement is the
+interesting part.
+
+Finish with the single incident you would hand to an analyst first, and what you would
+tell them to check.
+```
+
+## Follow-ups
+
+```text
+Show me every incident currently sitting in New status that is more than 48 hours old.
+Anything in there that should have been escalated?
+```
+
+```text
+Of the incidents you would close, pick the one you are least confident about and argue the
+opposite case. What would change your mind?
+```
+
+## What good looks like
+
+- A ranking that does not simply mirror the assigned severity. If it does, the model is
+  reading the severity field rather than the evidence.
+- At least one disagreement with the assigned severity, with a stated reason.
+- The "argue the opposite case" follow-up should produce a real counter-argument, not a
+  hedge.
+
+## Demo notes
+
+- This collection cannot query the data lake. If you want long-history context mid-triage,
+  switch to the data exploration collection - see
+  [risky-user-hunt](../DataExploration/risky-user-hunt.prompt.md).
+- You cannot choose a workspace with the triage tools. If your tenant has several, you get
+  what you get.
+- A quiet queue makes for a flat demo. Check you have ten incidents with real alert
+  evidence before you present, and drop the count if not.

--- a/Content/PromptBooks/Triage/user-investigation.prompt.md
+++ b/Content/PromptBooks/Triage/user-investigation.prompt.md
@@ -1,0 +1,72 @@
+---
+name: user-investigation
+description: User-centric view - their alerts, their devices, and whether they are the target or the vector.
+argument-hint: <user account ID>
+agent: agent
+---
+
+# User investigation
+
+**Demonstrates:** `ListUserRelatedAlerts` and `ListUserRelatedMachines`, plus hunting
+queries to close the gaps. The counterpart to
+[device-investigation](device-investigation.prompt.md): same investigation, pivoted on the
+person instead of the box.
+
+## Prerequisites
+
+- Triage collection connected
+- A user account ID
+
+## Prompt
+
+```text
+Investigate the user account ${input:userId}.
+
+Pull:
+- Every security alert associated with this account
+- Every device where they have active or recent sign-in sessions
+
+Then work out which of these this is:
+- The user is the TARGET (someone is attacking them)
+- The user is the VECTOR (their account is being used to attack others)
+- The user is the CAUSE (risky behaviour, not malice)
+- Nothing is wrong (the alerts are noise)
+
+Commit to one and give me the evidence. If the device list is wider than you would expect
+for one person's role, flag it.
+```
+
+## Follow-ups
+
+```text
+Look up the advanced hunting schemas you need, then run a hunting query showing this
+user's activity across all their devices in the last seven days, ordered by time. I want
+to see whether the activity follows the user or stays with one device.
+```
+
+```text
+Compare this user's device list against what you would expect for their role. Which of
+these devices should they not be signing in to?
+```
+
+```text
+If this account is compromised, which of those devices is the attacker most likely sitting
+on right now, and why that one?
+```
+
+## What good looks like
+
+- A committed classification. Target, vector, cause and noise call for four different
+  responses, and refusing to choose is the unhelpful answer.
+- The activity-follows-user-or-device distinction from the first follow-up is the single
+  most useful output here.
+- An honest "nothing is wrong" where that is true.
+
+## Demo notes
+
+- Works best on an account with a handful of alerts. A completely clean user gives you
+  nothing to reason about; an account drowning in alerts buries the narrative.
+- The triage collection cannot reach the data lake, so ninety-plus-day history is not
+  available here. If someone asks for the long baseline, that is the cue to switch to
+  [analyze-user-entity](../DataExploration/analyze-user-entity.prompt.md), which reasons
+  over lake data instead.

--- a/Content/PromptBooks/mcp.json
+++ b/Content/PromptBooks/mcp.json
@@ -1,11 +1,4 @@
 {
-  "_comment": [
-    "Microsoft Sentinel MCP server collections. Copy this file to .vscode/mcp.json",
-    "(the .vscode/ folder is git-ignored in this repo, which is why the template lives here).",
-    "VS Code prompts you to sign in on first use - use an account with at least Security Reader.",
-    "The server IDs below are referenced by the 'tools' frontmatter in every .prompt.md under",
-    "Content/PromptBooks/, so keep them as-is unless you also update the prompt files."
-  ],
   "servers": {
     "sentinel-data-exploration": {
       "type": "http",

--- a/Content/PromptBooks/mcp.json
+++ b/Content/PromptBooks/mcp.json
@@ -1,0 +1,23 @@
+{
+  "_comment": [
+    "Microsoft Sentinel MCP server collections. Copy this file to .vscode/mcp.json",
+    "(the .vscode/ folder is git-ignored in this repo, which is why the template lives here).",
+    "VS Code prompts you to sign in on first use - use an account with at least Security Reader.",
+    "The server IDs below are referenced by the 'tools' frontmatter in every .prompt.md under",
+    "Content/PromptBooks/, so keep them as-is unless you also update the prompt files."
+  ],
+  "servers": {
+    "sentinel-data-exploration": {
+      "type": "http",
+      "url": "https://sentinel.microsoft.com/mcp/data-exploration"
+    },
+    "sentinel-triage": {
+      "type": "http",
+      "url": "https://sentinel.microsoft.com/mcp/triage"
+    },
+    "sentinel-agent-creation": {
+      "type": "http",
+      "url": "https://sentinel.microsoft.com/mcp/security-copilot-agent-creation"
+    }
+  }
+}

--- a/Content/PromptBooks/vscode-settings.snippet.json
+++ b/Content/PromptBooks/vscode-settings.snippet.json
@@ -1,0 +1,19 @@
+{
+  "_comment": [
+    "Merge this into .vscode/settings.json so VS Code discovers the prompt files in this",
+    "folder. Without it, Copilot only looks in .github/prompts and the /slash-commands",
+    "below will not appear. Every prompt file also contains the literal prompt text, so",
+    "you can always fall back to copy-paste if this setting misbehaves.",
+    "",
+    "If settings.json IntelliSense flags the shape below, open the setting in the Settings",
+    "UI to confirm what your VS Code build expects - the key name is stable, the value",
+    "shape has changed across releases."
+  ],
+  "chat.promptFilesLocations": {
+    ".github/prompts": true,
+    "Content/PromptBooks/DataExploration": true,
+    "Content/PromptBooks/Triage": true,
+    "Content/PromptBooks/AgentCreation": true,
+    "Content/PromptBooks/SentinelAsCode": true
+  }
+}

--- a/Content/PromptBooks/vscode-settings.snippet.json
+++ b/Content/PromptBooks/vscode-settings.snippet.json
@@ -1,14 +1,4 @@
 {
-  "_comment": [
-    "Merge this into .vscode/settings.json so VS Code discovers the prompt files in this",
-    "folder. Without it, Copilot only looks in .github/prompts and the /slash-commands",
-    "below will not appear. Every prompt file also contains the literal prompt text, so",
-    "you can always fall back to copy-paste if this setting misbehaves.",
-    "",
-    "If settings.json IntelliSense flags the shape below, open the setting in the Settings",
-    "UI to confirm what your VS Code build expects - the key name is stable, the value",
-    "shape has changed across releases."
-  ],
   "chat.promptFilesLocations": {
     ".github/prompts": true,
     "Content/PromptBooks/DataExploration": true,

--- a/Deploy/content/sentinel-deployment.config
+++ b/Deploy/content/sentinel-deployment.config
@@ -3,7 +3,8 @@
     "Content/Parsers/UnifiedSignInLogs/UnifiedSignInLogs.yaml"
   ],
   "excludecontentfiles": [
-    "Content/Playbooks/Template"
+    "Content/Playbooks/Template",
+    "Content/PromptBooks"
   ],
   "parameterfilemappings": {}
 }

--- a/Docs/Content/Prompt-Books.md
+++ b/Docs/Content/Prompt-Books.md
@@ -153,9 +153,9 @@ Pass `compose_agent` the session ID from `start_agent_creation`, not the one fro
 | --- | --- | --- | --- |
 | Sentinel data lake | Required | - | - |
 | Defender portal onboarding | Graph tools only | Required | - |
-| Security Copilot | Entity analyzer only | - | Required |
+| Security Copilot | Entity analyser only | - | Required |
 | Minimum role | Security Reader | Your existing permissions | Security Copilot access |
-| Extra roles | Security Copilot Contributor for entity analyzer; Exposure Management read for graph | - | - |
+| Extra roles | Security Copilot Contributor for entity analyser; Exposure Management read for graph | - | - |
 
 ## Writing good prompts
 
@@ -176,7 +176,7 @@ Four incantations that change behaviour, all documented:
 | --- | --- |
 | The workspace ID, explicitly | With several workspaces connected, tools pick between them turn to turn |
 | `in my graph` | Scopes graph tools to the graph rather than the lake |
-| `render the results as returned exactly from the tool` | Stops the client re-summarising an entity-analyzer verdict |
+| `render the results as returned exactly from the tool` | Stops the client re-summarising an entity-analyser verdict |
 | `Use 'default' as the workspaceId.` | System tables have no workspace ID of their own |
 
 Two more that are not Microsoft's but earn their place in every prompt in this book:
@@ -235,7 +235,7 @@ the Copilot chat sidebar -> **Show Chat Debug View** -> **Export All as JSON**).
 
 ## Known limits
 
-**Entity analyzer**
+**Entity analyser**
 
 - `analyze_user_entity` caps the analysis window at **seven days**
 - Entra object IDs only. On-premises-only AD users are unsupported.

--- a/Docs/Content/Prompt-Books.md
+++ b/Docs/Content/Prompt-Books.md
@@ -1,0 +1,272 @@
+# Prompt Books - Microsoft Sentinel MCP prompts for GitHub Copilot
+
+Reference for the 18 prompt books under [`Content/PromptBooks/`](../../Content/PromptBooks):
+what each demonstrates, the MCP tools behind them, how to set them up, the running orders
+for a live demo, and the failure modes worth knowing before you present.
+
+These are demo assets, not deployable Sentinel content. Nothing here is picked up by the
+deploy pipelines.
+
+## What the Sentinel MCP server is
+
+Microsoft Sentinel exposes scenario-focused collections of MCP tools over a hosted server,
+authenticated with Microsoft Entra. Connect a compatible client (VS Code with GitHub
+Copilot, Security Copilot, Copilot Studio, Microsoft Foundry) and you can query security
+data in natural language without writing KQL or knowing the schema.
+
+Three collections, three endpoints:
+
+| Collection | Endpoint | What it does |
+| --- | --- | --- |
+| Data exploration | `https://sentinel.microsoft.com/mcp/data-exploration` | Search tables, query the lake, analyse entities, reason over graphs |
+| Triage | `https://sentinel.microsoft.com/mcp/triage` | Incidents, alerts, Defender entity APIs, advanced hunting |
+| Agent creation | `https://sentinel.microsoft.com/mcp/security-copilot-agent-creation` | Build and deploy Security Copilot agents |
+
+## Setup
+
+### 1. Register the MCP servers
+
+Copy the shipped template to the git-ignored VS Code folder:
+
+```bash
+cp Content/PromptBooks/mcp.json .vscode/mcp.json
+```
+
+Reload VS Code and sign in when prompted. Alternatively, **Ctrl+Shift+P** ->
+`MCP: Add Server` -> **HTTP** -> paste an endpoint URL -> give it a server ID.
+
+`.vscode/` is git-ignored in this repo (see [`.gitignore`](../../.gitignore) line 5), which
+is why the template lives under `Content/PromptBooks/` and gets copied rather than being
+committed in place.
+
+### 2. Make the prompts discoverable
+
+Merge [`vscode-settings.snippet.json`](../../Content/PromptBooks/vscode-settings.snippet.json)
+into `.vscode/settings.json`. VS Code only looks in `.github/prompts` by default, so
+without `chat.promptFilesLocations` the `/slash-commands` will not appear.
+
+If settings.json IntelliSense objects to the shape, check the Settings UI for what your VS
+Code build expects. The key name is stable; the value shape has moved across releases.
+Copy-paste out of the prompt files always works as a fallback.
+
+### 3. Agent mode
+
+MCP tools are only available in **agent mode**. Confirm with the **Configure Tools** icon
+that the Sentinel servers appear with their tools listed.
+
+## Catalogue
+
+### Data exploration (7)
+
+| Prompt | Tools exercised | Cost |
+| --- | --- | --- |
+| [`lake-orientation`](../../Content/PromptBooks/DataExploration/lake-orientation.prompt.md) | `list_sentinel_workspaces`, `search_tables` | Free |
+| [`risky-user-hunt`](../../Content/PromptBooks/DataExploration/risky-user-hunt.prompt.md) | `search_tables`, `query_lake` | Free |
+| [`signin-failure-triage`](../../Content/PromptBooks/DataExploration/signin-failure-triage.prompt.md) | `search_tables`, `query_lake` | Free |
+| [`analyze-user-entity`](../../Content/PromptBooks/DataExploration/analyze-user-entity.prompt.md) | `analyze_user_entity`, `get_entity_analysis` | SCUs |
+| [`analyze-url-entity`](../../Content/PromptBooks/DataExploration/analyze-url-entity.prompt.md) | `analyze_url_entity`, `get_entity_analysis` | SCUs |
+| [`retro-hunt-ioc-sweep`](../../Content/PromptBooks/DataExploration/retro-hunt-ioc-sweep.prompt.md) | `search_tables`, `query_lake` | Free |
+| [`exposure-blast-radius`](../../Content/PromptBooks/DataExploration/exposure-blast-radius.prompt.md) | `get_graph_context`, `find_blastradius`, `find_walkable_paths`, `find_exposure_perimeter` | Graph meter |
+
+### Triage (6)
+
+| Prompt | Tools exercised |
+| --- | --- |
+| [`incident-queue-triage`](../../Content/PromptBooks/Triage/incident-queue-triage.prompt.md) | `ListIncidents`, `GetIncidentById` |
+| [`incident-deep-dive`](../../Content/PromptBooks/Triage/incident-deep-dive.prompt.md) | `GetIncidentById`, `ListAlerts`, `GetAlertByID`, `RunAdvancedHuntingQuery` |
+| [`file-hash-investigation`](../../Content/PromptBooks/Triage/file-hash-investigation.prompt.md) | `GetDefenderFileInfo`, `GetDefenderFileStatistics`, `GetDefenderFileAlerts`, `GetDefenderFileRelatedMachines` |
+| [`device-investigation`](../../Content/PromptBooks/Triage/device-investigation.prompt.md) | `GetDefenderMachine`, `GetDefenderMachineAlerts`, `GetDefenderMachineLoggedOnUsers`, `GetDefenderMachineVulnerabilities` |
+| [`user-investigation`](../../Content/PromptBooks/Triage/user-investigation.prompt.md) | `ListUserRelatedAlerts`, `ListUserRelatedMachines` |
+| [`cve-exposure-sweep`](../../Content/PromptBooks/Triage/cve-exposure-sweep.prompt.md) | `ListDefenderMachinesByVulnerability`, `ListDefenderRemediationActivities` |
+
+### Agent creation (2)
+
+| Prompt | Tools exercised |
+| --- | --- |
+| [`build-triage-agent`](../../Content/PromptBooks/AgentCreation/build-triage-agent.prompt.md) | `search_for_tools`, `start_agent_creation`, `compose_agent`, `get_evaluation`, `deploy_agent` |
+| [`post-incident-report-agent`](../../Content/PromptBooks/AgentCreation/post-incident-report-agent.prompt.md) | Same chain, on Microsoft's own sample scenario |
+
+### Sentinel-As-Code (3)
+
+MCP plus this repository. These are the ones that make the demo about *this* repo rather
+than about Sentinel generally.
+
+| Prompt | What it does |
+| --- | --- |
+| [`hunt-to-analytical-rule`](../../Content/PromptBooks/SentinelAsCode/hunt-to-analytical-rule.prompt.md) | Validates a lake finding, then writes it as rule YAML matching this repo's schema, regenerates `dependencies.json` and runs the Pester suite |
+| [`validate-rule-against-lake`](../../Content/PromptBooks/SentinelAsCode/validate-rule-against-lake.prompt.md) | Checks a committed rule's tables, columns, 30-day fire count and entity-mapping null rates against real data |
+| [`detection-gap-analysis`](../../Content/PromptBooks/SentinelAsCode/detection-gap-analysis.prompt.md) | Splits coverage gaps into fixable, false-confidence and honest |
+
+## Tool reference
+
+### Data exploration collection
+
+| Tool | Purpose | Key parameters |
+| --- | --- | --- |
+| `list_sentinel_workspaces` | Workspace name and ID pairs. Run before anything else. | - |
+| `search_tables` | Semantic search over the table catalogue, returns schemas | `query`, `workspaceId` |
+| `query_lake` | Run one KQL query against a lake workspace | `query`, `workspaceId` |
+| `analyze_user_entity` | Start an AI risk analysis for a user | Entra object ID, `startTime`, `endTime`, `workspaceId` |
+| `analyze_url_entity` | Start an AI risk analysis for a URL or domain | URL, `startTime`, `endTime`, `workspaceId` |
+| `get_entity_analysis` | Poll for analysis results | `analysisId` |
+| `get_graph_context` | Valid node labels and properties. Run before other graph tools. | - |
+| `find_blastradius` | Propagation paths from a node towards critical assets | `sourceName` |
+| `find_walkable_paths` | Traversable connections between a source and target | `sourceName`, `targetName` |
+| `find_exposure_perimeter` | Incoming connections to an entity | `targetName`, `minPathLength`, `maxPathLength` |
+| `find_connected_nodes` | Paths between entities matching label criteria | `sourceNodeLabel`, `targetNodeLabel` |
+| `find_nodes` | Entities matching criteria | `validNodeLabel`, `validNodeProperties` |
+
+### Triage collection
+
+Incidents and alerts: `ListIncidents`, `GetIncidentById`, `ListAlerts`, `GetAlertByID`.
+
+Hunting: `FetchAdvancedHuntingTablesOverview`, `FetchAdvancedHuntingTablesDetailedSchema`,
+`RunAdvancedHuntingQuery`. Run the schema tool before writing KQL; it is the documented way
+to avoid malformed queries.
+
+Files: `GetDefenderFileInfo`, `GetDefenderFileStatistics`, `GetDefenderFileAlerts`,
+`GetDefenderFileRelatedMachines`.
+
+Devices: `GetDefenderMachine`, `GetDefenderMachineAlerts`, `GetDefenderMachineLoggedOnUsers`,
+`GetDefenderMachineVulnerabilities`, `FindDefenderMachineByIp`.
+
+Users: `ListUserRelatedAlerts`, `ListUserRelatedMachines`.
+
+Vulnerabilities and remediation: `ListDefenderMachinesByVulnerability`,
+`ListDefenderVulnerabilitiesBySoftware`, `ListDefenderRemediationActivities`,
+`GetDefenderRemediationActivity`.
+
+Indicators and investigations: `ListDefenderIndicators`, `ListDefenderInvestigations`,
+`GetDefenderInvestigation`, `GetDefenderIpAlerts`, `GetDefenderIpStatistics`.
+
+### Agent creation collection
+
+`search_for_tools`, `start_agent_creation`, `compose_agent`, `get_evaluation`,
+`deploy_agent`.
+
+Pass `compose_agent` the session ID from `start_agent_creation`, not the one from
+`search_for_tools`. They are different sessions.
+
+## Prerequisites
+
+| | Data exploration | Triage | Agent creation |
+| --- | --- | --- | --- |
+| Sentinel data lake | Required | - | - |
+| Defender portal onboarding | Graph tools only | Required | - |
+| Security Copilot | Entity analyzer only | - | Required |
+| Minimum role | Security Reader | Your existing permissions | Security Copilot access |
+| Extra roles | Security Copilot Contributor for entity analyzer; Exposure Management read for graph | - | - |
+
+## Writing good prompts
+
+Microsoft's own guidance is to be specific, and their contrast makes the point better than
+any rule:
+
+> `For user <UPN>, baseline their network, file, sign-in, and device events over 90 days
+> and compare with +/- 10 minutes to find anomalies or suspicious activities to help me
+> triage the severity and priority of this alert.`
+
+beats
+
+> `What is risky about <UPN>?`
+
+Four incantations that change behaviour, all documented:
+
+| Say this | Because |
+| --- | --- |
+| The workspace ID, explicitly | With several workspaces connected, tools pick between them turn to turn |
+| `in my graph` | Scopes graph tools to the graph rather than the lake |
+| `render the results as returned exactly from the tool` | Stops the client re-summarising an entity-analyzer verdict |
+| `Use 'default' as the workspaceId.` | System tables have no workspace ID of their own |
+
+Two more that are not Microsoft's but earn their place in every prompt in this book:
+
+- **Ask for the reasoning, not just the answer.** "Show me each KQL query you run" turns a
+  black box into a demo.
+- **Force a commitment.** "Commit to one verdict and justify it" beats a model hedging
+  across every option, which is the default failure mode on ambiguous evidence.
+
+## Running orders
+
+**15 minutes, mixed audience**
+
+1. `lake-orientation` - no schema knowledge needed
+2. `risky-user-hunt` - the model writes, breaks and fixes its own KQL
+3. `analyze-user-entity` - one call replaces twenty minutes of context gathering
+4. `hunt-to-analytical-rule` - and the finding becomes a pull request
+
+**30 minutes, SOC audience**
+
+1. `lake-orientation`
+2. `incident-queue-triage` - it disagrees with your severities
+3. `incident-deep-dive` - on whatever it ranked first
+4. `file-hash-investigation` or `device-investigation` - follow the evidence
+5. `analyze-user-entity` - the verdict
+6. `retro-hunt-ioc-sweep` - have we ever seen this, not have we seen this recently
+
+**30 minutes, detection engineering audience**
+
+1. `lake-orientation`
+2. `detection-gap-analysis` - the false-confidence gap usually lands hardest
+3. `validate-rule-against-lake` - on whatever it flagged
+4. `hunt-to-analytical-rule` - close the loop
+5. `build-triage-agent` - if Security Copilot is provisioned
+
+**Cost-sensitive demo:** stay in the data exploration collection and skip
+`analyze-user-entity`, `analyze-url-entity` (SCUs) and `exposure-blast-radius` (graph
+meter). Everything else is free.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Unknown tool '<server>/*' will be ignored` in a prompt file | `tools:` frontmatter naming an MCP server that is not registered | The shipped files carry no `tools:` key for this reason. If you added one, register the server with that exact ID or drop the line. |
+| Tools never get called | Overlapping tools, weak model, or context favoured over tool use | Disable collections you are not using; pick a newer reasoning model; start a fresh chat |
+| Results come from the wrong workspace | Several workspaces connected | Name the workspace ID in the prompt |
+| Intermittent `HTTP 404 Resource not found` | Token refresh bug | Remove the MCP server, restart VS Code, add it again |
+| Consistent `HTTP 404` when adding the server | Tenant not registered, or no data lake workspace access | Check data lake onboarding and your role |
+| `HTTP 403 Unauthorized to access account` | Client does not support MCP auth | Update VS Code |
+| No results at all | Table absent, query too narrow, invalid workspace ID, or missing permission | Broaden the search; re-run `list_sentinel_workspaces`; check Lake explorer |
+| Guest sign-in authenticates against the wrong tenant | Known VS Code issue; triage tools do not support multi-tenancy | Add an `x-mcp-client-tenant-id` header to the server definition, or use a home-tenant account |
+| Default workspace missing from the list | System tables have no workspace ID | Add `Use 'default' as the workspaceId.` to the prompt |
+
+To collect evidence for a support case, use the VS Code **Chat Debug View** (three dots in
+the Copilot chat sidebar -> **Show Chat Debug View** -> **Export All as JSON**).
+
+## Known limits
+
+**Entity analyzer**
+
+- `analyze_user_entity` caps the analysis window at **seven days**
+- Entra object IDs only. On-premises-only AD users are unsupported.
+- Requires `AlertEvidence`, `SigninLogs`, `CloudAppEvents` and `IdentityInfo` in the lake
+- Run at most **five** analyses concurrently
+
+**Triage collection**
+
+- Cannot query the data lake. Use the data exploration collection for long history.
+- Cannot choose a workspace
+- No guest or delegated access; home tenant only
+- File tools disagree on hash types: `GetDefenderFileInfo` and `GetDefenderFileStatistics`
+  take SHA-1 or SHA-256; `GetDefenderFileAlerts` and `GetDefenderFileRelatedMachines` take
+  **SHA-1 only**. MD5 works nowhere. Supply SHA-1 when chaining.
+
+**Graph tools**
+
+- Preview; subject to change
+- Identity lookups do not accept UPNs
+- Put the entity type before the name (`device zava-fin-01`)
+- Invoke the graph meter, so they cost money
+
+## Related
+
+- [Spark Notebooks](Spark-Notebooks.md) - the same hunts as PySpark notebooks. `demo13`
+  is the notebook twin of `retro-hunt-ioc-sweep`; `demo18` pairs with
+  `detection-gap-analysis`.
+- [GitHub Copilot Setup](../GitHub/GitHub-Copilot.md) - the repo's own Copilot
+  customisations and the platform support matrix for prompt files
+- [Analytical Rules](Analytical-Rules.md) - the schema `hunt-to-analytical-rule` writes to
+- Microsoft docs: [MCP overview](https://learn.microsoft.com/azure/sentinel/datalake/sentinel-mcp-overview),
+  [tool collections](https://learn.microsoft.com/azure/sentinel/datalake/sentinel-mcp-tools-overview),
+  [VS Code setup](https://learn.microsoft.com/azure/sentinel/datalake/sentinel-mcp-use-tool-visual-studio-code),
+  [best practices and troubleshooting](https://learn.microsoft.com/azure/sentinel/datalake/troubleshoot-sentinel-mcp)

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -26,6 +26,7 @@ cross-links the matching [Toolkit](#toolkit--companion-vs-code-extension) pages.
 | [Hunting Queries](Content/Hunting-Queries.md) | YAML schema for hunting queries: required fields, tactics/techniques tags, export guide |
 | [Parsers](Content/Parsers.md) | YAML schema for KQL parsers/functions deployed as workspace saved functions (stage 1 of the content deploy order) via the `savedSearches` API |
 | [Playbooks](Content/Playbooks.md) | ARM template requirements, MSI vs standard connections, auto-injected parameters |
+| [Prompt Books](Content/Prompt-Books.md) | The 18 Sentinel MCP prompt books for GitHub Copilot: setup, tool reference for all three collections, prompt-writing guidance, demo running orders and troubleshooting |
 | [Spark Notebooks](Content/Spark-Notebooks.md) | Catalogue of the 18 Sentinel data lake advanced-analytics notebooks (F16): technique, tables, visual and why-not-KQL for each, workspace configuration via `apply_config.py`, the threat-hunting running order, and the Advanced data insights cost model |
 | [Summary Rules](Content/Summary-Rules.md) | Summary-rule JSON schema, allowed bin sizes, KQL restrictions, system columns |
 | [Watchlists](Content/Watchlists.md) | Watchlist metadata schema, CSV format, KQL usage examples |


### PR DESCRIPTION
## Summary

Adds 18 prompt books for the Microsoft Sentinel MCP server, built to run in VS Code with GitHub Copilot agent mode, plus the drop-in server configuration and full reference documentation.

## Why is this change needed?

The Sentinel MCP server exposes three scenario-focused tool collections that let an analyst query the data lake, triage incidents and build Security Copilot agents in natural language. Getting value out of them depends almost entirely on prompt quality, and Microsoft's own guidance is blunt about it: a vague prompt returns vague results.

Nothing in this repo captured that. Demo prompts lived in people's heads and chat history, which meant they were not reviewable, not repeatable, and not improvable. Several of the constraints below are the sort of thing you only discover by hitting them live.

The `SentinelAsCode/` group exists for a second reason: it connects the MCP tooling back to this repository. A finding from the lake becomes a committed analytics rule rather than evaporating when the chat window closes.

## What does this change do?

Adds `Content/PromptBooks/`, grouped by MCP tool collection:

- **DataExploration (7)** - workspace and table discovery, the risky-user hunt, sign-in failure triage, the user and URL entity analyzers, a full-history IOC retro-hunt, and the preview graph tools for blast radius and attack paths.
- **Triage (6)** - incident queue ranking, incident deep dive, file hash investigation, device investigation, user investigation, and CVE exposure sweep.
- **AgentCreation (2)** - the full `search_for_tools` to `deploy_agent` chain, and Microsoft's own post-incident report scenario.
- **SentinelAsCode (3)** - hunt to analytics rule, validate a committed rule against real data, and detection gap analysis across the rule and hunting-query library.

Each book carries a primary prompt, follow-ups that build a narrative, a *what good looks like* section so a presenter can tell live whether it worked, and demo notes covering the failure modes.

Configuration ships as templates (`mcp.json`, `vscode-settings.snippet.json`) copied into `.vscode/` rather than committed there, because `.vscode/` is git-ignored in this repo.

**Two decisions worth a reviewer's attention:**

No prompt file pins a `tools:` list. Naming an MCP server that is not yet registered produces `promptValidator.unknownExtensionOrMcpServerReference` in the editor, and a squiggle in every file is a poor way to start a demo. Without the key, the prompt uses whatever tools are enabled in chat. Per-prompt scoping is genuinely worth adding back once server IDs are known - Microsoft's troubleshooting guidance is that models pick tools badly when too many overlapping ones are enabled - so the README documents the exact line to add for each collection.

Constraints are documented from Microsoft's reference rather than inferred, and several are non-obvious:

- `analyze_user_entity` caps its window at seven days, needs an Entra object ID rather than a UPN, and requires four specific tables in the lake
- The four Defender file tools disagree on hash types: two accept SHA-1 or SHA-256, two accept SHA-1 only, MD5 works nowhere. The file investigation book leads with that, because a SHA-256 half-completes the chain and is confusing to debug live.
- Graph tools need `in my graph` in the prompt to scope correctly, and do not accept UPNs for identity lookups
- The entity analyzer needs `render the results as returned exactly from the tool`, or the client re-summarises a verdict that is already a summary

## What does this fix or affect?

No behavioural change. New content type, excluded from the Sentinel content scanner via `Deploy/content/sentinel-deployment.config` (matching how `Content/Playbooks/Template` is handled), and not deployed by any pipeline.

Cost is flagged per book: the entity analyzer consumes Security Compute Units, the graph tools invoke the graph meter, and everything else in the data exploration and triage collections is free. There is a cost-sensitive running order in the docs for demos where that matters.

## Type of change

- [x] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [x] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [ ] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Files changed (high level)

- `Content/PromptBooks/{DataExploration,Triage,AgentCreation,SentinelAsCode}/*.prompt.md` - the 18 books
- `Content/PromptBooks/mcp.json` - server definitions for all three collections
- `Content/PromptBooks/vscode-settings.snippet.json` - the `chat.promptFilesLocations` entry that makes them discoverable
- `Content/PromptBooks/README.md` - catalogue and setup
- `Docs/Content/Prompt-Books.md` - full tool reference for all three collections, prompt-writing guidance, three demo running orders, troubleshooting table and known limits
- `Docs/README.md` - index the new content-type doc
- `Deploy/content/sentinel-deployment.config` - exclude the folder from the content scanner

## Pre-merge checklist

- [x] **Pester suite** passes locally (`./Tools/Invoke-PRValidation.ps1 -RepoPath .`) - 7257 passed, 0 failed, 391 skipped
- [ ] **Bicep build** - not applicable, no Bicep changed
- [ ] **`dependencies.json` regenerated** - not applicable, no KQL content added
- [ ] **Cross-platform parity** - not applicable, no pipeline or workflow changes
- [x] **Path-scoped instructions** still match the touched content type's schema
- [x] **No secrets** in committed files - no tenant identifiers, workspace names, UPNs or addresses
- [x] **Commit messages** follow conventional-commit format
- [x] **Documentation** updated

## Testing

**Static verification, automated and repeatable:**

- All 18 prompt files carry valid frontmatter against the documented VS Code prompt-file schema, with unique slash-command names matching their filenames
- Every relative link resolves, including the cross-references into `Content/SparkNotebooks/` and `Docs/Content/Spark-Notebooks.md` (this branch is based on `main` after #45 merged, so those targets exist)
- Both JSON configuration files parse, as does the amended deployment config
- No em-dashes or section signs, per repo writing conventions
- Committed content scanned for tenant identifiers: none

**Full Pester suite:** 7257 passed, 0 failed, 391 skipped.

**Not yet done:** the prompts have not been executed against a live Sentinel MCP server. Every tool name, parameter and documented constraint is taken from Microsoft's published reference rather than observed behaviour, so the books are accurate as written but unproven in practice. Worth running the DataExploration set against a data-lake workspace before using them in front of an audience.

One item I could not confirm from Microsoft's documentation: the exact JSON shape of `chat.promptFilesLocations`. The setting is described but never shown, so the snippet ships the object form with a note to check the Settings UI if it is rejected. Every book also contains its prompt as plain text, so copy-paste works regardless.

## Related

- #45 - the Spark notebook suite. The retro-hunt and detection-gap books cross-reference `demo13` and `demo18`, which are the notebook equivalents of the same hunts.
- Separately, the repo-root `.gitignore` needs its generic `.env` rule restored. It has been narrowed to two specific paths, leaving `Tools/ClassicToDcr/Rehearsal/.env` (service-principal secrets) unignored. Not in this PR.
