### PR TITLE
feat(connectors): add the Sophos Central codeless connector package

### DIFF
--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -1,0 +1,216 @@
+<#
+.SYNOPSIS
+    Deploys the Sophos Central CCF (Codeless Connector Framework) package to a Microsoft Sentinel workspace.
+
+.DESCRIPTION
+    Deploys, in order:
+      1. Custom tables            (Sophos_Table.json)
+      2. Data Collection Rule     (Sophos_DCR.json, kind = Direct)
+      3. Connector definition     (Sophos_ConnectorDefinition.json)
+      4. Data connector pollers   (Sophos_PollingConfig.json)  [optional]
+
+    Template placeholders ({{location}}, {{workspaceResourceId}}, {{dataCollectionEndpoint}},
+    {{dataCollectionRuleImmutableId}}) are resolved automatically at deploy time.
+
+    The poller step (4) is only run when -ClientId and -ClientSecret are supplied. Otherwise the
+    connector appears in Sentinel and you complete the connection from the UI (Data connectors >
+    Sophos Central > Connect). Secrets are read directly by this script and are never printed.
+
+.PARAMETER SubscriptionId
+    Target Azure subscription ID.
+
+.PARAMETER ResourceGroup
+    Resource group that contains the Log Analytics / Sentinel workspace.
+
+.PARAMETER WorkspaceName
+    Name of the Log Analytics workspace onboarded to Microsoft Sentinel.
+
+.PARAMETER Location
+    Azure region (e.g. eastus, uksouth). Defaults to the workspace's region if omitted.
+
+.PARAMETER ClientId
+    (Optional) Sophos Central API Client ID. Supply with -ClientSecret to also deploy the pollers.
+
+.PARAMETER ClientSecret
+    (Optional) Sophos Central API Client Secret (SecureString).
+
+.EXAMPLE
+    ./Deploy-SophosConnector.ps1 -SubscriptionId <sub> -ResourceGroup rg-sentinel -WorkspaceName ws-sentinel
+
+.EXAMPLE
+    ./Deploy-SophosConnector.ps1 -SubscriptionId <sub> -ResourceGroup rg-sentinel -WorkspaceName ws-sentinel `
+        -ClientId <id> -ClientSecret (Read-Host -AsSecureString "Sophos Client Secret")
+
+.NOTES
+    Requires: Azure CLI (az) logged in with rights to create tables, DCRs, and Sentinel resources.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $SubscriptionId,
+    [Parameter(Mandatory)] [string] $ResourceGroup,
+    [Parameter(Mandatory)] [string] $WorkspaceName,
+    [Parameter()]          [string] $Location,
+    [Parameter()]          [string] $ClientId,
+    [Parameter()]          [securestring] $ClientSecret
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- API versions --------------------------------------------------------------
+$apiTables    = '2023-01-01-preview'
+$apiDcr       = '2023-03-11'
+$apiConnDef   = '2022-09-01-preview'
+$apiConnector = '2023-02-01-preview'
+$apiWorkspace = '2023-09-01'
+
+# --- Paths ---------------------------------------------------------------------
+$root            = $PSScriptRoot
+$tableFile       = Join-Path $root 'Sophos_Table.json'
+$dcrFile         = Join-Path $root 'Sophos_DCR.json'
+$connDefFile     = Join-Path $root 'Sophos_ConnectorDefinition.json'
+$pollingFile     = Join-Path $root 'Sophos_PollingConfig.json'
+
+foreach ($f in @($tableFile, $dcrFile, $connDefFile, $pollingFile)) {
+    if (-not (Test-Path $f)) { throw "Required file not found: $f" }
+}
+
+# --- Helpers -------------------------------------------------------------------
+function Write-Step { param([string]$Message) Write-Host "`n==> $Message" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Message) Write-Host "    [OK] $Message" -ForegroundColor Green }
+
+function Invoke-AzRestPut {
+    param([string]$Url, [string]$BodyJson)
+
+    $tmp = New-TemporaryFile
+    try {
+        Set-Content -Path $tmp -Value $BodyJson -Encoding utf8
+        $result = az rest --method put --url $Url --headers 'Content-Type=application/json' --body "@$tmp" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "PUT $Url failed:`n$result"
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$result)) { return $null }
+        return ($result | ConvertFrom-Json -Depth 100)
+    }
+    finally {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-AzRestGet {
+    param([string]$Url)
+    $result = az rest --method get --url $Url 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "GET $Url failed:`n$result" }
+    return ($result | ConvertFrom-Json -Depth 100)
+}
+
+# --- 0. Context ----------------------------------------------------------------
+Write-Step "Verifying Azure CLI session"
+$account = az account show 2>&1 | ConvertFrom-Json -ErrorAction SilentlyContinue
+if (-not $account) { throw "Not logged in. Run 'az login' first." }
+az account set --subscription $SubscriptionId | Out-Null
+Write-Ok "Subscription set to $SubscriptionId"
+
+$workspaceResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.OperationalInsights/workspaces/$WorkspaceName"
+
+Write-Step "Resolving workspace"
+$ws = Invoke-AzRestGet -Url "https://management.azure.com$workspaceResourceId`?api-version=$apiWorkspace"
+if (-not $Location) { $Location = $ws.location }
+Write-Ok "Workspace '$WorkspaceName' in '$Location'"
+
+# --- 1. Custom tables ----------------------------------------------------------
+Write-Step "Deploying custom tables"
+$tables = Get-Content $tableFile -Raw | ConvertFrom-Json -Depth 100
+foreach ($table in $tables) {
+    $tableName = $table.name
+    $body = @{ properties = @{ schema = $table.properties.schema } } | ConvertTo-Json -Depth 100
+    $url  = "https://management.azure.com$workspaceResourceId/tables/$tableName`?api-version=$apiTables"
+    Invoke-AzRestPut -Url $url -BodyJson $body | Out-Null
+    Write-Ok "Table $tableName"
+}
+
+# --- 2. Data Collection Rule ---------------------------------------------------
+Write-Step "Deploying Data Collection Rule"
+$dcrRaw = Get-Content $dcrFile -Raw
+$dcrRaw = $dcrRaw.Replace('{{location}}', $Location).Replace('{{workspaceResourceId}}', $workspaceResourceId)
+$dcr    = $dcrRaw | ConvertFrom-Json -Depth 100
+
+$dcrName = $dcr.name
+$dcrBody = @{
+    location   = $Location
+    kind       = $dcr.kind
+    properties = $dcr.properties
+} | ConvertTo-Json -Depth 100
+
+$dcrResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Insights/dataCollectionRules/$dcrName"
+$dcrResult = Invoke-AzRestPut -Url "https://management.azure.com$dcrResourceId`?api-version=$apiDcr" -BodyJson $dcrBody
+
+$dcrImmutableId = $dcrResult.properties.immutableId
+$dcrEndpoint    = $null
+if ($dcrResult.properties.PSObject.Properties.Name -contains 'endpoints') {
+    $dcrEndpoint = $dcrResult.properties.endpoints.logsIngestion
+}
+if (-not $dcrImmutableId) {
+    # Re-read to be safe (some API versions omit immutableId on PUT response)
+    $dcrResult = Invoke-AzRestGet -Url "https://management.azure.com$dcrResourceId`?api-version=$apiDcr"
+    $dcrImmutableId = $dcrResult.properties.immutableId
+    if ($dcrResult.properties.PSObject.Properties.Name -contains 'endpoints') {
+        $dcrEndpoint = $dcrResult.properties.endpoints.logsIngestion
+    }
+}
+Write-Ok "DCR $dcrName (immutableId: $dcrImmutableId)"
+if ($dcrEndpoint) { Write-Ok "Ingestion endpoint: $dcrEndpoint" }
+
+# --- 3. Connector definition ---------------------------------------------------
+Write-Step "Deploying connector definition"
+$connDefRaw = (Get-Content $connDefFile -Raw).Replace('{{location}}', $Location)
+$connDef    = $connDefRaw | ConvertFrom-Json -Depth 100
+$connDefName = $connDef.name
+$connDefBody = @{
+    kind         = $connDef.kind
+    location     = $Location
+    properties   = $connDef.properties
+} | ConvertTo-Json -Depth 100
+
+$connDefUrl = "https://management.azure.com$workspaceResourceId/providers/Microsoft.SecurityInsights/dataConnectorDefinitions/$connDefName`?api-version=$apiConnDef"
+Invoke-AzRestPut -Url $connDefUrl -BodyJson $connDefBody | Out-Null
+Write-Ok "Connector definition $connDefName"
+
+# --- 4. Data connector pollers (optional) --------------------------------------
+if ($ClientId -and $ClientSecret) {
+    if (-not $dcrEndpoint) {
+        throw "DCR did not expose a logs ingestion endpoint; cannot deploy pollers automatically. Complete the connection from the Sentinel UI instead."
+    }
+
+    Write-Step "Deploying data connector pollers"
+    $plainSecret = [System.Net.NetworkCredential]::new('', $ClientSecret).Password
+
+    $pollingRaw = (Get-Content $pollingFile -Raw).
+        Replace('{{location}}', $Location).
+        Replace('{{dataCollectionEndpoint}}', $dcrEndpoint).
+        Replace('{{dataCollectionRuleImmutableId}}', $dcrImmutableId).
+        Replace('{{clientId}}', $ClientId).
+        Replace('{{clientSecret}}', $plainSecret)
+
+    $pollers = $pollingRaw | ConvertFrom-Json -Depth 100
+    foreach ($poller in $pollers) {
+        $pollerName = $poller.name
+        $pollerBody = @{
+            kind       = $poller.kind
+            properties = $poller.properties
+        } | ConvertTo-Json -Depth 100
+
+        $pollerUrl = "https://management.azure.com$workspaceResourceId/providers/Microsoft.SecurityInsights/dataConnectors/$pollerName`?api-version=$apiConnector"
+        Invoke-AzRestPut -Url $pollerUrl -BodyJson $pollerBody | Out-Null
+        Write-Ok "Poller $pollerName"
+    }
+    $plainSecret = $null
+}
+else {
+    Write-Step "Skipping poller deployment (no credentials supplied)"
+    Write-Host "    Complete the connection in Microsoft Sentinel:" -ForegroundColor Yellow
+    Write-Host "    Data connectors > 'Sophos Central (using REST API)' > Connect" -ForegroundColor Yellow
+}
+
+Write-Host "`nDeployment complete." -ForegroundColor Green

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -1,3 +1,9 @@
+#
+# Sentinel-As-Code/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+#
+# Created by noodlemctwoodle on 20/08/2026.
+#
+
 <#
 .SYNOPSIS
     Deploys the Sophos Central CCF (Codeless Connector Framework) package to a Microsoft Sentinel workspace.
@@ -14,7 +20,9 @@
 
     The poller step (4) is only run when -ClientId and -ClientSecret are supplied. Otherwise the
     connector appears in Sentinel and you complete the connection from the UI (Data connectors >
-    Sophos Central > Connect). Secrets are read directly by this script and are never printed.
+    Sophos Central > Connect). The client secret is held only as a SecureString and, when the
+    pollers are deployed, is passed to the Azure CLI as an in-memory argument. It is never
+    written to disk and never printed.
 
 .PARAMETER SubscriptionId
     Target Azure subscription ID.
@@ -59,11 +67,15 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 # --- API versions --------------------------------------------------------------
-$apiTables    = '2023-01-01-preview'
-$apiDcr       = '2023-03-11'
-$apiConnDef   = '2022-09-01-preview'
-$apiConnector = '2023-02-01-preview'
-$apiWorkspace = '2023-09-01'
+# Pinned to the versions the repository standardises on, see the $apiVersions map in
+# Tools/Documenter/Export-SentinelInventory.ps1. dataConnectorDefinitions and the
+# RestApiPoller connector kind are preview-only resource types, so both use the
+# repository's SentinelPreview pin rather than the Sentinel GA pin.
+$apiTables    = '2023-09-01'         # Tables
+$apiDcr       = '2023-03-11'         # DataCollection
+$apiConnDef   = '2024-10-01-preview' # SentinelPreview
+$apiConnector = '2024-10-01-preview' # SentinelPreview
+$apiWorkspace = '2025-02-01'         # OperationalInsights
 
 # --- Paths ---------------------------------------------------------------------
 $root            = $PSScriptRoot
@@ -81,21 +93,20 @@ function Write-Step { param([string]$Message) Write-Host "`n==> $Message" -Foreg
 function Write-Ok   { param([string]$Message) Write-Host "    [OK] $Message" -ForegroundColor Green }
 
 function Invoke-AzRestPut {
+    # The body is passed as an in-memory argument rather than via a temporary file. The
+    # poller bodies carry the Sophos client secret, and a temp file would place that secret
+    # on disk with default ACLs for the lifetime of the call. PowerShell passes native
+    # arguments without shell re-parsing, so the JSON needs no escaping here.
     param([string]$Url, [string]$BodyJson)
 
-    $tmp = New-TemporaryFile
-    try {
-        Set-Content -Path $tmp -Value $BodyJson -Encoding utf8
-        $result = az rest --method put --url $Url --headers 'Content-Type=application/json' --body "@$tmp" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            throw "PUT $Url failed:`n$result"
-        }
-        if ([string]::IsNullOrWhiteSpace([string]$result)) { return $null }
-        return ($result | ConvertFrom-Json -Depth 100)
+    $result = az rest --method put --url $Url --headers 'Content-Type=application/json' --body $BodyJson 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # $result can echo the request body, which may contain the client secret, so report
+        # the failing URL and status only.
+        throw "PUT $Url failed with exit code $LASTEXITCODE."
     }
-    finally {
-        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
-    }
+    if ([string]::IsNullOrWhiteSpace([string]$result)) { return $null }
+    return ($result | ConvertFrom-Json -Depth 100)
 }
 
 function Invoke-AzRestGet {
@@ -141,7 +152,9 @@ $dcrBody = @{
     location   = $Location
     kind       = $dcr.kind
     properties = $dcr.properties
-} | ConvertTo-Json -Depth 100
+}
+if ($dcr.PSObject.Properties.Name -contains 'tags' -and $dcr.tags) { $dcrBody.tags = $dcr.tags }
+$dcrBody = $dcrBody | ConvertTo-Json -Depth 100
 
 $dcrResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Insights/dataCollectionRules/$dcrName"
 $dcrResult = Invoke-AzRestPut -Url "https://management.azure.com$dcrResourceId`?api-version=$apiDcr" -BodyJson $dcrBody
@@ -171,7 +184,9 @@ $connDefBody = @{
     kind         = $connDef.kind
     location     = $Location
     properties   = $connDef.properties
-} | ConvertTo-Json -Depth 100
+}
+if ($connDef.PSObject.Properties.Name -contains 'tags' -and $connDef.tags) { $connDefBody.tags = $connDef.tags }
+$connDefBody = $connDefBody | ConvertTo-Json -Depth 100
 
 $connDefUrl = "https://management.azure.com$workspaceResourceId/providers/Microsoft.SecurityInsights/dataConnectorDefinitions/$connDefName`?api-version=$apiConnDef"
 Invoke-AzRestPut -Url $connDefUrl -BodyJson $connDefBody | Out-Null

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
@@ -4,10 +4,6 @@
     "type": "Microsoft.SecurityInsights/dataConnectorDefinitions",
     "location": "{{location}}",
     "kind": "Customizable",
-    "availability": {
-        "isPreview": true,
-        "status": 1
-    },
     "properties": {
         "connectorUiConfig": {
             "id": "SophosConnectorDefinition",
@@ -61,7 +57,7 @@
                 "resourceProvider": [
                     {
                         "provider": "Microsoft.OperationalInsights/workspaces",
-                        "permissionsDisplayText": "read and write permissions are required.",
+                        "permissionsDisplayText": "read, write, and delete permissions are required. Delete is used by the Disconnect action, which removes the data connector resource.",
                         "providerDisplayName": "Workspace",
                         "scope": "Workspace",
                         "requiredPermissions": {

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
@@ -1,0 +1,116 @@
+{
+    "name": "SophosConnectorDefinition",
+    "apiVersion": "2022-09-01-preview",
+    "type": "Microsoft.SecurityInsights/dataConnectorDefinitions",
+    "location": "{{location}}",
+    "kind": "Customizable",
+    "availability": {
+        "isPreview": true,
+        "status": 1
+    },
+    "properties": {
+        "connectorUiConfig": {
+            "id": "SophosConnectorDefinition",
+            "title": "Sophos Central (using REST API)",
+            "publisher": "CC-Engineering",
+            "logo": "",
+            "descriptionMarkdown": "The [Sophos Central](https://www.sophos.com/en-us/products/sophos-central) data connector provides the capability to ingest security events and alerts from the Sophos Central SIEM API into Microsoft Sentinel. The connector polls the `/siem/v1/events` and `/siem/v1/alerts` endpoints to bring endpoint detections, threat activity, and security alerts into your workspace for correlation, analytics, and hunting.",
+            "graphQueriesTableName": "SophosEvents_CL",
+            "graphQueries": [
+                {
+                    "metricName": "Total Sophos events received",
+                    "legend": "Sophos Events",
+                    "baseQuery": "SophosEvents_CL"
+                },
+                {
+                    "metricName": "Total Sophos alerts received",
+                    "legend": "Sophos Alerts",
+                    "baseQuery": "SophosAlerts_CL"
+                }
+            ],
+            "sampleQueries": [
+                {
+                    "description": "Top 10 Sophos event types",
+                    "query": "SophosEvents_CL\n | summarize count() by EventType\n | top 10 by count_"
+                },
+                {
+                    "description": "High severity Sophos alerts",
+                    "query": "SophosAlerts_CL\n | where Severity == \"high\"\n | sort by TimeGenerated desc"
+                }
+            ],
+            "dataTypes": [
+                {
+                    "name": "SophosEvents_CL",
+                    "lastDataReceivedQuery": "SophosEvents_CL\n | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+                },
+                {
+                    "name": "SophosAlerts_CL",
+                    "lastDataReceivedQuery": "SophosAlerts_CL\n | summarize Time = max(TimeGenerated)\n | where isnotempty(Time)"
+                }
+            ],
+            "connectivityCriteria": [
+                {
+                    "type": "HasDataConnectors"
+                }
+            ],
+            "availability": {
+                "isPreview": true,
+                "status": 1
+            },
+            "permissions": {
+                "resourceProvider": [
+                    {
+                        "provider": "Microsoft.OperationalInsights/workspaces",
+                        "permissionsDisplayText": "read and write permissions are required.",
+                        "providerDisplayName": "Workspace",
+                        "scope": "Workspace",
+                        "requiredPermissions": {
+                            "write": true,
+                            "read": true,
+                            "delete": true
+                        }
+                    }
+                ],
+                "customs": [
+                    {
+                        "name": "Sophos Central API credentials",
+                        "description": "A Sophos Central API Client ID and Client Secret are required. Create an API Credential from the Sophos Central admin console under **Global Settings** > **API Credentials Management**."
+                    }
+                ]
+            },
+            "instructionSteps": [
+                {
+                    "title": "Connect Sophos Central to Microsoft Sentinel",
+                    "description": "Provide the Sophos Central API Client ID and Client Secret to authenticate and begin collecting events and alerts.\n\n>**NOTE:** This connector uses the Sophos Central SIEM API. Ensure you have created an API Credential in the Sophos Central admin console (**Global Settings** > **API Credentials Management**) with access to the SIEM integration.",
+                    "instructions": [
+                        {
+                            "type": "Textbox",
+                            "parameters": {
+                                "label": "Client ID",
+                                "placeholder": "Client ID",
+                                "type": "text",
+                                "name": "clientId"
+                            }
+                        },
+                        {
+                            "type": "Textbox",
+                            "parameters": {
+                                "label": "Client Secret",
+                                "placeholder": "Client Secret",
+                                "type": "password",
+                                "name": "clientSecret"
+                            }
+                        },
+                        {
+                            "type": "ConnectionToggleButton",
+                            "parameters": {
+                                "connectLabel": "Connect",
+                                "name": "connect"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json
@@ -1,6 +1,6 @@
 {
     "name": "SophosConnectorDefinition",
-    "apiVersion": "2022-09-01-preview",
+    "apiVersion": "2024-10-01-preview",
     "type": "Microsoft.SecurityInsights/dataConnectorDefinitions",
     "location": "{{location}}",
     "kind": "Customizable",

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_DCR.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_DCR.json
@@ -1,0 +1,86 @@
+{
+    "name": "SophosDCR",
+    "apiVersion": "2024-03-11",
+    "type": "Microsoft.Insights/dataCollectionRules",
+    "kind": "Direct",
+    "location": "{{location}}",
+    "tags": {
+        "createdBy": "SentinelCodelessConnector"
+    },
+    "properties": {
+        "streamDeclarations": {
+            "Custom-SophosEvents_CL": {
+                "columns": [
+                    { "name": "amsi_threat_data", "type": "dynamic" },
+                    { "name": "appCerts", "type": "dynamic" },
+                    { "name": "appSha256", "type": "string" },
+                    { "name": "core_remedy_items", "type": "dynamic" },
+                    { "name": "created_at", "type": "string" },
+                    { "name": "customer_id", "type": "string" },
+                    { "name": "details", "type": "dynamic" },
+                    { "name": "endpoint_id", "type": "string" },
+                    { "name": "endpoint_type", "type": "string" },
+                    { "name": "group", "type": "string" },
+                    { "name": "id", "type": "string" },
+                    { "name": "ips_threat_data", "type": "dynamic" },
+                    { "name": "location", "type": "string" },
+                    { "name": "name", "type": "string" },
+                    { "name": "origin", "type": "string" },
+                    { "name": "severity", "type": "string" },
+                    { "name": "source", "type": "string" },
+                    { "name": "source_info", "type": "dynamic" },
+                    { "name": "threat", "type": "string" },
+                    { "name": "event_type", "type": "string" },
+                    { "name": "user_id", "type": "string" },
+                    { "name": "when", "type": "string" },
+                    { "name": "whitelist_properties", "type": "dynamic" }
+                ]
+            },
+            "Custom-SophosAlerts_CL": {
+                "columns": [
+                    { "name": "actionable", "type": "boolean" },
+                    { "name": "allowedActions", "type": "dynamic" },
+                    { "name": "category", "type": "string" },
+                    { "name": "created_at", "type": "string" },
+                    { "name": "customer_id", "type": "string" },
+                    { "name": "data", "type": "dynamic" },
+                    { "name": "description", "type": "string" },
+                    { "name": "event_service_event_id", "type": "string" },
+                    { "name": "id", "type": "string" },
+                    { "name": "info", "type": "dynamic" },
+                    { "name": "javaUUID", "type": "string" },
+                    { "name": "location", "type": "string" },
+                    { "name": "product", "type": "string" },
+                    { "name": "severity", "type": "string" },
+                    { "name": "source", "type": "string" },
+                    { "name": "threat", "type": "string" },
+                    { "name": "threat_cleanable", "type": "boolean" },
+                    { "name": "device_type", "type": "string" },
+                    { "name": "when", "type": "string" }
+                ]
+            }
+        },
+        "destinations": {
+            "logAnalytics": [
+                {
+                    "workspaceResourceId": "{{workspaceResourceId}}",
+                    "name": "clv2ws1"
+                }
+            ]
+        },
+        "dataFlows": [
+            {
+                "streams": ["Custom-SophosEvents_CL"],
+                "destinations": ["clv2ws1"],
+                "outputStream": "Custom-SophosEvents_CL",
+                "transformKql": "source | extend TimeGenerated = todatetime(['when']) | project TimeGenerated, AmsiThreatData = todynamic(amsi_threat_data), AppCerts = todynamic(appCerts), AppSha256 = tostring(appSha256), CoreRemedyItems = todynamic(core_remedy_items), CreatedAt = tostring(created_at), CustomerId = tostring(customer_id), Details = todynamic(details), EndpointId = tostring(endpoint_id), EndpointType = tostring(endpoint_type), Group = tostring(['group']), Id = tostring(id), IpsThreatData = todynamic(ips_threat_data), Location = tostring(location), Name = tostring(name), Origin = tostring(origin), Severity = tostring(severity), Source = tostring(source), SourceInfo = todynamic(source_info), Threat = tostring(threat), EventType = tostring(event_type), UserId = tostring(user_id), When = tostring(['when']), WhitelistProperties = todynamic(whitelist_properties)"
+            },
+            {
+                "streams": ["Custom-SophosAlerts_CL"],
+                "destinations": ["clv2ws1"],
+                "outputStream": "Custom-SophosAlerts_CL",
+                "transformKql": "source | extend TimeGenerated = todatetime(['when']) | project TimeGenerated, Actionable = tobool(actionable), AllowedActions = todynamic(allowedActions), Category = tostring(category), CreatedAt = tostring(created_at), CustomerId = toguid(customer_id), Data = todynamic(data), Description = tostring(description), EventServiceEventId = toguid(event_service_event_id), Id = toguid(id), Info = todynamic(info), JavaUUID = toguid(javaUUID), Location = tostring(location), Product = tostring(product), Severity = tostring(severity), Source = tostring(source), Threat = tostring(threat), ThreatCleanable = tobool(threat_cleanable), DeviceType = tostring(device_type), When = tostring(['when'])"
+            }
+        ]
+    }
+}

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_DCR.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_DCR.json
@@ -1,6 +1,6 @@
 {
     "name": "SophosDCR",
-    "apiVersion": "2024-03-11",
+    "apiVersion": "2023-03-11",
     "type": "Microsoft.Insights/dataCollectionRules",
     "kind": "Direct",
     "location": "{{location}}",

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_PollingConfig.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_PollingConfig.json
@@ -1,0 +1,108 @@
+[
+  {
+    "type": "Microsoft.SecurityInsights/dataConnectors",
+    "apiVersion": "2023-02-01-preview",
+    "name": "SophosEventsConnector",
+    "location": "{{location}}",
+    "kind": "RestApiPoller",
+    "properties": {
+      "connectorDefinitionName": "SophosConnectorDefinition",
+      "dataType": "SophosEvents_CL",
+      "dcrConfig": {
+        "streamName": "Custom-SophosEvents_CL",
+        "dataCollectionEndpoint": "{{dataCollectionEndpoint}}",
+        "dataCollectionRuleImmutableId": "{{dataCollectionRuleImmutableId}}"
+      },
+      "auth": {
+        "type": "OAuth2",
+        "GrantType": "client_credentials",
+        "ClientId": "{{clientId}}",
+        "ClientSecret": "{{clientSecret}}",
+        "TokenEndpoint": "https://id.sophos.com/api/v2/oauth2/token",
+        "Scope": "token"
+      },
+      "request": {
+        "apiEndpoint": "https://api.central.sophos.com/siem/v1/events",
+        "httpMethod": "GET",
+        "queryTimeFormat": "UnixTimestamp",
+        "rateLimitQPS": 10,
+        "queryWindowInMin": 5,
+        "retryCount": 3,
+        "timeoutInSeconds": 60,
+        "headers": {
+          "Accept": "application/json"
+        },
+        "StartTimeAttributeName": "from_date",
+        "queryParameters": {
+          "limit": "1000"
+        }
+      },
+      "paging": {
+        "pagingType": "NextPageToken",
+        "nextPageTokenJsonPath": "$.next_cursor",
+        "NextPageParaName": "cursor",
+        "hasNextFlagJsonPath": "$.has_more",
+        "pageSize": 1000
+      },
+      "response": {
+        "eventsJsonPaths": [
+          "$.items"
+        ],
+        "format": "json"
+      }
+    }
+  },
+  {
+    "type": "Microsoft.SecurityInsights/dataConnectors",
+    "apiVersion": "2023-02-01-preview",
+    "name": "SophosAlertsConnector",
+    "location": "{{location}}",
+    "kind": "RestApiPoller",
+    "properties": {
+      "connectorDefinitionName": "SophosConnectorDefinition",
+      "dataType": "SophosAlerts_CL",
+      "dcrConfig": {
+        "streamName": "Custom-SophosAlerts_CL",
+        "dataCollectionEndpoint": "{{dataCollectionEndpoint}}",
+        "dataCollectionRuleImmutableId": "{{dataCollectionRuleImmutableId}}"
+      },
+      "auth": {
+        "type": "OAuth2",
+        "GrantType": "client_credentials",
+        "ClientId": "{{clientId}}",
+        "ClientSecret": "{{clientSecret}}",
+        "TokenEndpoint": "https://id.sophos.com/api/v2/oauth2/token",
+        "Scope": "token"
+      },
+      "request": {
+        "apiEndpoint": "https://api.central.sophos.com/siem/v1/alerts",
+        "httpMethod": "GET",
+        "queryTimeFormat": "UnixTimestamp",
+        "rateLimitQPS": 10,
+        "queryWindowInMin": 5,
+        "retryCount": 3,
+        "timeoutInSeconds": 60,
+        "headers": {
+          "Accept": "application/json"
+        },
+        "StartTimeAttributeName": "from_date",
+        "queryParameters": {
+          "limit": "1000"
+        }
+      },
+      "paging": {
+        "pagingType": "NextPageToken",
+        "nextPageTokenJsonPath": "$.next_cursor",
+        "NextPageParaName": "cursor",
+        "hasNextFlagJsonPath": "$.has_more",
+        "pageSize": 1000
+      },
+      "response": {
+        "eventsJsonPaths": [
+          "$.items"
+        ],
+        "format": "json"
+      }
+    }
+  }
+]

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_PollingConfig.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_PollingConfig.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "Microsoft.SecurityInsights/dataConnectors",
-    "apiVersion": "2023-02-01-preview",
+    "apiVersion": "2024-10-01-preview",
     "name": "SophosEventsConnector",
     "location": "{{location}}",
     "kind": "RestApiPoller",
@@ -54,7 +54,7 @@
   },
   {
     "type": "Microsoft.SecurityInsights/dataConnectors",
-    "apiVersion": "2023-02-01-preview",
+    "apiVersion": "2024-10-01-preview",
     "name": "SophosAlertsConnector",
     "location": "{{location}}",
     "kind": "RestApiPoller",

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_Table.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_Table.json
@@ -1,0 +1,72 @@
+[
+    {
+        "name": "SophosEvents_CL",
+        "type": "Microsoft.OperationalInsights/workspaces/tables",
+        "apiVersion": "2025-02-01",
+        "location": "{{location}}",
+        "properties": {
+            "schema": {
+                "name": "SophosEvents_CL",
+                "columns": [
+                    { "name": "TimeGenerated", "type": "datetime", "description": "Event timestamp" },
+                    { "name": "AmsiThreatData", "type": "dynamic", "description": "AMSI Threat data associated with the threat, if available" },
+                    { "name": "AppCerts", "type": "dynamic", "description": "Certificate info of the application associated with the threat, if available" },
+                    { "name": "AppSha256", "type": "string", "description": "SHA 256 hash of the application associated with the threat, if available" },
+                    { "name": "CoreRemedyItems", "type": "dynamic", "description": "Details of the items cleaned or restored" },
+                    { "name": "CreatedAt", "type": "string", "description": "The date at which the event was created" },
+                    { "name": "CustomerId", "type": "string", "description": "The identifier of the customer for which record is created" },
+                    { "name": "Details", "type": "dynamic", "description": "Event detail properties" },
+                    { "name": "EndpointId", "type": "string", "description": "The corresponding endpoint id associated with the record" },
+                    { "name": "EndpointType", "type": "string", "description": "The corresponding endpoint type associated with the record" },
+                    { "name": "Group", "type": "string", "description": "The group associated with the event" },
+                    { "name": "Id", "type": "string", "description": "The identifier for the event" },
+                    { "name": "IpsThreatData", "type": "dynamic", "description": "IPS Threat data associated with the threat, if available" },
+                    { "name": "Location", "type": "string", "description": "The location captured for this record" },
+                    { "name": "Name", "type": "string", "description": "The name of the record created" },
+                    { "name": "Origin", "type": "string", "description": "Originating component of a detection" },
+                    { "name": "Severity", "type": "string", "description": "The severity for this event" },
+                    { "name": "Source", "type": "string", "description": "The source for this record" },
+                    { "name": "SourceInfo", "type": "dynamic", "description": "Detailed source information for this record" },
+                    { "name": "Threat", "type": "string", "description": "The threat associated with the record" },
+                    { "name": "EventType", "type": "string", "description": "The type of this record" },
+                    { "name": "UserId", "type": "string", "description": "The identifier of the user for which record is created" },
+                    { "name": "When", "type": "string", "description": "The date at which the event was created" },
+                    { "name": "WhitelistProperties", "type": "dynamic", "description": "Endpoint whitelist properties" }
+                ]
+            }
+        }
+    },
+    {
+        "name": "SophosAlerts_CL",
+        "type": "Microsoft.OperationalInsights/workspaces/tables",
+        "apiVersion": "2025-02-01",
+        "location": "{{location}}",
+        "properties": {
+            "schema": {
+                "name": "SophosAlerts_CL",
+                "columns": [
+                    { "name": "TimeGenerated", "type": "datetime", "description": "Alert timestamp" },
+                    { "name": "Actionable", "type": "boolean", "description": "The Event Services actionable" },
+                    { "name": "AllowedActions", "type": "dynamic", "description": "Allowed actions for the alert" },
+                    { "name": "Category", "type": "string", "description": "The category of the product from which this alert originated" },
+                    { "name": "CreatedAt", "type": "string", "description": "The date at which the alert was created" },
+                    { "name": "CustomerId", "type": "guid", "description": "The unique identifier of the customer linked with this record" },
+                    { "name": "Data", "type": "dynamic", "description": "Additional data associated with the alert" },
+                    { "name": "Description", "type": "string", "description": "The description of the alert that was generated" },
+                    { "name": "EventServiceEventId", "type": "guid", "description": "The Event Services event id" },
+                    { "name": "Id", "type": "guid", "description": "Identifier for the alert" },
+                    { "name": "Info", "type": "dynamic", "description": "Additional info associated with the alert" },
+                    { "name": "JavaUUID", "type": "guid", "description": "Java UUID for the record" },
+                    { "name": "Location", "type": "string", "description": "The location captured for this record" },
+                    { "name": "Product", "type": "string", "description": "The product from which this alert originated" },
+                    { "name": "Severity", "type": "string", "description": "The severity for this alert" },
+                    { "name": "Source", "type": "string", "description": "Describes the source from which alert was generated" },
+                    { "name": "Threat", "type": "string", "description": "The name of the threat responsible for the generation of alert" },
+                    { "name": "ThreatCleanable", "type": "boolean", "description": "Whether the threat is cleanable" },
+                    { "name": "DeviceType", "type": "string", "description": "Describes the type of the device on which alert was generated" },
+                    { "name": "When", "type": "string", "description": "The date at which the alert was created" }
+                ]
+            }
+        }
+    }
+]

--- a/Content/CodelessConnectors/Sophos_CCF/Sophos_Table.json
+++ b/Content/CodelessConnectors/Sophos_CCF/Sophos_Table.json
@@ -2,7 +2,7 @@
     {
         "name": "SophosEvents_CL",
         "type": "Microsoft.OperationalInsights/workspaces/tables",
-        "apiVersion": "2025-02-01",
+        "apiVersion": "2023-09-01",
         "location": "{{location}}",
         "properties": {
             "schema": {
@@ -39,7 +39,7 @@
     {
         "name": "SophosAlerts_CL",
         "type": "Microsoft.OperationalInsights/workspaces/tables",
-        "apiVersion": "2025-02-01",
+        "apiVersion": "2023-09-01",
         "location": "{{location}}",
         "properties": {
             "schema": {


### PR DESCRIPTION
## Summary

Adds a Codeless Connector Framework (CCF) package for Sophos Central, ingesting SIEM API events and alerts into Microsoft Sentinel with no Logic App or Function App in the path. Also establishes `Content/CodelessConnectors/` as the home for CCF content in this repository.

## Why is this change needed?

Sophos Central endpoint detections and alerts were not reachable from the workspace, so endpoint threat activity sat outside correlation, analytics, and hunting. Anything built on it had to be pivoted manually in the Sophos console.

The available options for closing that gap were a Logic App or a Function App poller. Both carry a hosting footprint, their own identity and secret handling, and their own failure modes to monitor, for what is fundamentally a scheduled REST poll. CCF moves the polling into the Sentinel platform itself, so there is no compute to run, patch, or pay for, and the connector state is visible in the data connectors blade rather than in a separate resource.

This is also the first CCF package in the repository, so it sets the directory layout and the deploy pattern that later connectors follow.

## What does this change do?

Adds a five-file CCF package plus a deployment script.

Ingestion path: the pollers call the Sophos SIEM API and post to the DCR ingestion endpoint, the DCR transform reshapes each record, and rows land in two custom tables.

- **Auth** is OAuth2 client credentials against `id.sophos.com`, with the token endpoint and `token` scope declared in the poller config.
- **Paging** is `NextPageToken` over the `cursor` parameter, driven by `$.has_more` and `$.next_cursor`, at 1000 records per page with a 5-minute query window.
- **Field naming** accepts the raw Sophos snake_case at the stream declaration and translates to Sentinel-friendly PascalCase in the DCR transform, keeping translation in exactly one place rather than spread between the stream, the transform, and the table.
- **Placeholders** (`{{location}}`, `{{workspaceResourceId}}`, `{{dataCollectionEndpoint}}`, `{{dataCollectionRuleImmutableId}}`) are resolved at deploy time rather than hardcoded, so the package is portable across workspaces and regions.
- **Poller deployment is optional.** Without `-ClientId` and `-ClientSecret` the script stops after the connector definition and the operator finishes from the Sentinel UI. The secret is taken as a `SecureString`, passed to the Azure CLI as an in-memory argument, and is never written to disk or printed.
- **API versions** follow the `$apiVersions` map in `Tools/Documenter/Export-SentinelInventory.ps1`. The two preview-only resource types (`dataConnectorDefinitions` and the `RestApiPoller` connector kind) use the SentinelPreview pin, since they are not exposed on the Sentinel GA surface.

## What does this fix or affect?

No behavioural change to anything existing. This is additive content and no existing deployment path references the new directory.

Note for reviewers: `requiredPermissions` on the connector definition declares `delete` alongside read and write. That block is declarative, it tells the connector blade what to check and display and grants nothing by itself. Delete is exercised by the Disconnect action, which removes the `dataConnectors` resource under the workspace scope.

## Type of change

- [x] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [ ] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [ ] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Files changed (high level)

- `Content/CodelessConnectors/Sophos_CCF/Sophos_Table.json` - custom table schemas for `SophosEvents_CL` and `SophosAlerts_CL`, PascalCase columns with per-column descriptions
- `Content/CodelessConnectors/Sophos_CCF/Sophos_DCR.json` - Direct-kind DCR declaring the `Custom-Sophos*_CL` streams, with the KQL transforms that map the API fields onto the table columns
- `Content/CodelessConnectors/Sophos_CCF/Sophos_ConnectorDefinition.json` - the gallery tile: graph queries, sample queries, connectivity criteria, required permissions, and the connection instructions rendered in the blade
- `Content/CodelessConnectors/Sophos_CCF/Sophos_PollingConfig.json` - two `RestApiPoller` connectors, one for `/siem/v1/events` and one for `/siem/v1/alerts`
- `Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1` - resolves the placeholders and applies tables, DCR, connector definition, and pollers in dependency order via the Azure CLI

## Pre-merge checklist

- [ ] **Pester suite** passes locally (`./Tools/Invoke-PRValidation.ps1 -RepoPath .`)
- [ ] **Bicep build** passes locally if Bicep changed (`az bicep build --file Infra/sentinel/main.bicep --stdout > /dev/null`)
- [ ] **`dependencies.json` regenerated** if KQL content changed (`./Tools/Build-DependencyManifest.ps1 -Mode Generate`)
- [ ] **Cross-platform parity** maintained if pipelines/workflows changed (ADO + GitHub both updated)
- [x] **Path-scoped instructions** still match the touched content type's schema
- [x] **No secrets** in committed files (env vars, hardcoded tokens, connection strings)
- [x] **Commit messages** follow conventional-commit format (type(scope): subject + detailed body)
- [x] **Documentation** updated if the change affects user-visible behaviour

Not ticked above: no Bicep, KQL content, or pipeline files are touched by this PR, and the Pester suite under `Tests/` does not currently cover `Content/CodelessConnectors/`, so running it locally would not exercise this change. The `validate` check still runs it against the repository as a whole.

## Testing

Static validation only. Being explicit, because this has not been deployed anywhere:

- All four JSON templates parse cleanly.
- `Deploy-SophosConnector.ps1` parses cleanly via the PowerShell language parser. PSScriptAnalyzer reports no errors; the only warnings are `PSAvoidUsingWriteHost`, consistent with the existing `Deploy/*.ps1` scripts, which use `Write-Host` for coloured console output.
- Scanned for embedded credentials; none present.
- Confirmed `properties.connectorUiConfig.availability` survived the removal of the duplicate top-level block.

**Not done, and it matters before anyone relies on this.** The script has not been run against a workspace, so the DCR transforms, the poller paging behaviour, and the revised API versions are validated by convention and by reading the API contract, not by a successful call. An end-to-end run against `stl-sec-siem-law` with live Sophos credentials is the outstanding piece: it is the only thing that will confirm records actually land in `SophosEvents_CL` and `SophosAlerts_CL` with the columns populated as intended.

There is also no `-WhatIf` path in the script yet. Every step is a PUT, so a dry run would need to be built rather than passed through.

## Required PR-validation status checks

- `template` - PR description matches the template (this file)
- `validate` - Pester suite under Tests/
- `bicep-build` - `az bicep build` against Infra/**/*.bicep
- `arm-validate` - Test-AzResourceGroupDeployment -WhatIf for playbooks (OIDC)
- `kql-validate` - Microsoft.Azure.Kusto.Language parser across all queries
- `dependency-manifest` - dependencies.json drift gate

## Related

No existing issue. Follow-up worth opening: `Content/CodelessConnectors/` is not covered by any CI validation job, so a schema test for CCF packages would be sensible once a second connector lands here.