### PR TITLE
fix(rules): correct requiredDataConnectors metadata on 14 analytical rules

### DIFF
--- a/Content/AnalyticalRules/AWS/AwsGuarddutyAlertDetectionRule.yaml
+++ b/Content/AnalyticalRules/AWS/AwsGuarddutyAlertDetectionRule.yaml
@@ -3,36 +3,40 @@ name: AWS Guard Duty Alert
 description: |
   'Amazon GuardDuty is a threat detection service that continuously monitors your AWS accounts and workloads for malicious activity and delivers detailed security findings for visibility and remediation. This templates create an alert for each Amazon GuardDuty finding.'
 severity: Medium
+requiredDataConnectors:
+  - connectorId: AwsS3ServerAccessLogsDefinition
+    dataTypes:
+      - AWSGuardDuty
 queryFrequency: PT1H
 queryPeriod: PT2H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- InitialAccess
-- Execution
-- Persistence
-- PrivilegeEscalation
-- DefenseEvasion
-- CredentialAccess
-- Discovery
-- LateralMovement
-- Collection
-- Exfiltration
-- Impact
+  - InitialAccess
+  - Execution
+  - Persistence
+  - PrivilegeEscalation
+  - DefenseEvasion
+  - CredentialAccess
+  - Discovery
+  - LateralMovement
+  - Collection
+  - Exfiltration
+  - Impact
 relevantTechniques:
-- T1046
-- T1078
-- T1078.004
-- T1098
-- T1098.001
-- T1110
-- T1110.001
-- T1110.003
-- T1190
-- T1496
-- T1530
-- T1537
+  - T1046
+  - T1078
+  - T1078.004
+  - T1098
+  - T1098.001
+  - T1110
+  - T1110.001
+  - T1110.003
+  - T1190
+  - T1496
+  - T1530
+  - T1537
 query: |
   // https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings.html
   AWSGuardDuty
@@ -171,38 +175,36 @@ query: |
   | extend CloudApplicationId = '11599'
   | extend IsSample = iff(ServiceDetails.additionalInfo.['sample'] == "true", true, false)
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: Name
-    columnName: AccountName
-  - identifier: UPNSuffix
-    columnName: UPNSuffix
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: RemoteIpAddress
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: LocalIpAddress
-- entityType: CloudApplication
-  fieldMappings:
-  - identifier: AppId
-    columnName: CloudApplicationId
-sentinelEntitiesMappings:
-- columnName: MalwareEntities
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: AccountName
+      - identifier: UPNSuffix
+        columnName: UPNSuffix
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: RemoteIpAddress
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: LocalIpAddress
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: AppId
+        columnName: CloudApplicationId
 alertDetailsOverride:
-  alertDisplayNameFormat: '{{Title}}'
-  alertDescriptionFormat: '{{Description}}'
+  alertDisplayNameFormat: "{{Title}}"
+  alertDescriptionFormat: "{{Description}}"
   alertTacticsColumnName: ThreatPurpose
   alertSeverityColumnName: Severity
   alertDynamicProperties:
-  - alertProperty: AlertLink
-    value: FindingLink
-  - alertProperty: ProductName
-    value: ProductName
-  - alertProperty: ProviderName
-    value: ProviderName
+    - alertProperty: AlertLink
+      value: FindingLink
+    - alertProperty: ProductName
+      value: ProductName
+    - alertProperty: ProviderName
+      value: ProviderName
 customDetails:
   ThreatFamilyName: ThreatFamilyName
   ResourceTypeAffected: ResourceTypeAffected
@@ -226,6 +228,8 @@ incidentConfiguration:
 version: 1.0.3
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- AWS
+  - Sentinel-As-Code
+  - Custom
+  - AWS
+sentinelEntitiesMappings:
+  - columnName: MalwareEntities

--- a/Content/AnalyticalRules/AzureActivity/NewDataConnectorDeploymentDetectionRule.yaml
+++ b/Content/AnalyticalRules/AzureActivity/NewDataConnectorDeploymentDetectionRule.yaml
@@ -6,7 +6,7 @@ severity: Informational
 requiredDataConnectors:
 - connectorId: AzureActivity
   dataTypes:
-  - AuditLogs
+  - AzureActivity
 queryFrequency: PT5H
 queryPeriod: PT5H
 triggerOperator: gt

--- a/Content/AnalyticalRules/AzureActivity/NewDcrCreationDetectionRule.yaml
+++ b/Content/AnalyticalRules/AzureActivity/NewDcrCreationDetectionRule.yaml
@@ -6,7 +6,7 @@ severity: Informational
 requiredDataConnectors:
 - connectorId: AzureActivity
   dataTypes:
-  - AuditLogs
+  - AzureActivity
 queryFrequency: PT5H
 queryPeriod: PT5H
 triggerOperator: gt

--- a/Content/AnalyticalRules/AzureActivity/PotentialTorExitNodeDetected.yaml
+++ b/Content/AnalyticalRules/AzureActivity/PotentialTorExitNodeDetected.yaml
@@ -4,9 +4,9 @@ description: |
   'Azure Activity detected from a TOR exit node'
 severity: Medium
 requiredDataConnectors:
-- connectorId: YourConnectorId
+- connectorId: AzureActivity
   dataTypes:
-  - YourDataType
+  - AzureActivity
 queryFrequency: P1D
 queryPeriod: P1D
 triggerOperator: gt

--- a/Content/AnalyticalRules/AzureActivity/TokenReplayWorkloadIdentityOutsideAzureDetectionRule.yaml
+++ b/Content/AnalyticalRules/AzureActivity/TokenReplayWorkloadIdentityOutsideAzureDetectionRule.yaml
@@ -6,24 +6,28 @@ description: |
   1. A workload identity is used to access Azure resources.
   2. The workload identity is used from an IP address that is not in Azure IP ranges.
 severity: High
+requiredDataConnectors:
+  - connectorId: AzureActivity
+    dataTypes:
+      - AzureActivity
 queryFrequency: PT1H
 queryPeriod: P1D
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- CredentialAccess
-- DefenseEvasion
-- InitialAccess
-- LateralMovement
-- Persistence
-- PrivilegeEscalation
+  - CredentialAccess
+  - DefenseEvasion
+  - InitialAccess
+  - LateralMovement
+  - Persistence
+  - PrivilegeEscalation
 relevantTechniques:
-- T1078
-- T1078.004
-- T1528
-- T1550
-- T1550.001
+  - T1078
+  - T1078.004
+  - T1528
+  - T1550
+  - T1550.001
 query: |
   let AzureRanges = externaldata(changeNumber: string, cloud: string, values: dynamic)
       ["https://raw.githubusercontent.com/microsoft/mstic/master/PublicFeeds/MSFTIPRanges/ServiceTags_Public.json"] with(format='multijson')
@@ -82,28 +86,28 @@ query: |
   | where IpAddressType == "None Azure IP"
   | project TimeGenerated,OperationNameValue,ResourceGroup,SubscriptionId,_ResourceId,CallerIpAddress,WorkloadIdentityName,WorkloadIdentityType,ServicePrincipalObjectId,ApplicationId,IsFirstPartyApp,EntraIdRoles,AppRolePermissions,WorkloadIdClassification,ActivityIpAddress,Uti,ConditionalAccessPolicies,ConditionalAccessStatus,UniqueTokenIdentifier,IpAddressType,CorrelationId,Caller,Category,EventSubmissionTimestamp,Authorization,ResourceProviderValue
 entityMappings:
-- entityType: CloudApplication
-  fieldMappings:
-  - identifier: Name
-    columnName: WorkloadIdentityName
-- entityType: CloudApplication
-  fieldMappings:
-  - identifier: AppId
-    columnName: ApplicationId
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: ActivityIpAddress
-- entityType: AzureResource
-  fieldMappings:
-  - identifier: ResourceId
-    columnName: _ResourceId
-- entityType: Account
-  fieldMappings:
-  - identifier: AadUserId
-    columnName: ServicePrincipalObjectId
-  - identifier: Name
-    columnName: ServicePrincipalObjectId
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: Name
+        columnName: WorkloadIdentityName
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: AppId
+        columnName: ApplicationId
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: ActivityIpAddress
+  - entityType: AzureResource
+    fieldMappings:
+      - identifier: ResourceId
+        columnName: _ResourceId
+  - entityType: Account
+    fieldMappings:
+      - identifier: AadUserId
+        columnName: ServicePrincipalObjectId
+      - identifier: Name
+        columnName: ServicePrincipalObjectId
 customDetails:
   WorkloadIdentityName: WorkloadIdentityName
   WorkloadIdentityType: WorkloadIdentityType
@@ -124,12 +128,12 @@ incidentConfiguration:
     lookbackDuration: P1D
     matchingMethod: Selected
     groupByEntities:
-    - CloudApplication
+      - CloudApplication
     groupByAlertDetails: []
     groupByCustomDetails: []
 version: 1.0.1
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Azure Activity
+  - Sentinel-As-Code
+  - Custom
+  - Azure Activity

--- a/Content/AnalyticalRules/AzureWAF/AzureFirewallMultipleDenyActionsDetectionRule.yaml
+++ b/Content/AnalyticalRules/AzureWAF/AzureFirewallMultipleDenyActionsDetectionRule.yaml
@@ -4,28 +4,28 @@ description: |
   'Identifies attack pattern when attacker tries to move, or scan, from resource to resource on the network and creates an incident when a source has more than 1 registered deny action in Azure Firewall.'
 severity: Medium
 requiredDataConnectors:
-- connectorId: AzureFirewall
-  dataTypes:
-  - AzureDiagnostics
-  - AZFWApplicationRule
-  - AZFWNetworkRule
+  - connectorId: AzureFirewall
+    dataTypes:
+      - AZFWApplicationRule
+      - AZFWNetworkRule
+      - AzureDiagnostics
 queryFrequency: PT1H
 queryPeriod: PT1H
 triggerOperator: gt
 triggerThreshold: 1
 enabled: true
 tactics:
-- CommandAndControl
-- Discovery
-- LateralMovement
-- Reconnaissance
+  - CommandAndControl
+  - Discovery
+  - LateralMovement
+  - Reconnaissance
 relevantTechniques:
-- T1046
-- T1071
-- T1071.001
-- T1210
-- T1595
-- T1595.002
+  - T1046
+  - T1071
+  - T1071.001
+  - T1210
+  - T1595
+  - T1595.002
 query: |
   let threshold = 10;
   union isfuzzy=true(
@@ -50,17 +50,17 @@ query: |
   | summarize StartTime = min(TimeGenerated), count() by SourceIp, Fqdn, Action, Protocol
   | where count_ >= ["threshold"])
 entityMappings:
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: SourceIp
-- entityType: URL
-  fieldMappings:
-  - identifier: Url
-    columnName: Fqdn
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SourceIp
+  - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: Fqdn
 version: 1.1.1
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Azure WAF
+  - Sentinel-As-Code
+  - Custom
+  - Azure WAF

--- a/Content/AnalyticalRules/Custom/ChangeWasMadeToTailscale.yaml
+++ b/Content/AnalyticalRules/Custom/ChangeWasMadeToTailscale.yaml
@@ -4,25 +4,25 @@ description: |
   'The alert rule was disabled due to too many consecutive failures. Reason: A table referenced in the query was not found. Verify that the relevant data source is connected. A change was made to Tailscale'
 severity: Medium
 requiredDataConnectors:
-- connectorId: YourConnectorId
-  dataTypes:
-  - YourDataType
+  - connectorId: TailscaleCCF
+    dataTypes:
+      - TailscaleAudit_CL
 queryFrequency: PT1H
 queryPeriod: PT1H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- DefenseEvasion
-- Impact
-- Persistence
+  - DefenseEvasion
+  - Impact
+  - Persistence
 relevantTechniques:
-- T1485
-- T1562
-- T1562.001
-- T1562.004
-- T1565
-- T1565.001
+  - T1485
+  - T1562
+  - T1562.001
+  - T1562.004
+  - T1565
+  - T1565.001
 query: |
   TailscaleAudit_CL
   | where Action has_any ("ENABLE", "DISABLE")
@@ -30,10 +30,10 @@ query: |
   , TargetProperty = tolower(replace_string(TargetProperty, '_', ' '))
   | project EventTime, ActorLoginName, Origin, TargetProperty, TargetType
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: FullName
-    columnName: ActorLoginName
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: ActorLoginName
 eventGroupingSettings:
   aggregationKind: SingleAlert
 incidentConfiguration:
@@ -49,5 +49,5 @@ incidentConfiguration:
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
+  - Sentinel-As-Code
+  - Custom

--- a/Content/AnalyticalRules/DNS/PotentialExploitationOfCve202449112LdapNightmare.yaml
+++ b/Content/AnalyticalRules/DNS/PotentialExploitationOfCve202449112LdapNightmare.yaml
@@ -6,22 +6,22 @@ description: |
   https://www.safebreach.com/blog/ldapnightmare-safebreach-labs-publishes-first-proof-of-concept-exploit-for-cve-2024-49113/
 severity: High
 requiredDataConnectors:
-- connectorId: YourConnectorId
-  dataTypes:
-  - YourDataType
+  - connectorId: ASimDnsActivityLogs
+    dataTypes:
+      - ASimDnsActivityLogs
 queryFrequency: PT1H
 queryPeriod: PT1H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- InitialAccess
-- Execution
-- Discovery
+  - InitialAccess
+  - Execution
+  - Discovery
 relevantTechniques:
-- T1018
-- T1190
-- T1203
+  - T1018
+  - T1190
+  - T1203
 query: |
   ASimDnsActivityLogs
   | where TimeGenerated > ago(1h)
@@ -34,18 +34,18 @@ query: |
   | where DnsQueryType == "33"
   | where DnsResponseCode == 0
 entityMappings:
-- entityType: Host
-  fieldMappings:
-  - identifier: HostName
-    columnName: DvcHostname
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: SrcIpAddr
-- entityType: IP
-  fieldMappings:
-  - identifier: Address
-    columnName: DvcIpAddr
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: DvcHostname
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: SrcIpAddr
+  - entityType: IP
+    fieldMappings:
+      - identifier: Address
+        columnName: DvcIpAddr
 eventGroupingSettings:
   aggregationKind: SingleAlert
 incidentConfiguration:
@@ -61,6 +61,6 @@ incidentConfiguration:
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- DNS
+  - Sentinel-As-Code
+  - Custom
+  - DNS

--- a/Content/AnalyticalRules/DeviceEvents/SmartScreenPotentialPhishingUrlClicked.yaml
+++ b/Content/AnalyticalRules/DeviceEvents/SmartScreenPotentialPhishingUrlClicked.yaml
@@ -4,22 +4,24 @@ description: |
   'MDE has detected a user that has potentially clicked an email with a phishing URL.'
 severity: High
 requiredDataConnectors:
-- connectorId: YourConnectorId
-  dataTypes:
-  - YourDataType
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - EmailEvents
+      - EmailUrlInfo
+      - DeviceEvents
 queryFrequency: P1D
 queryPeriod: P1D
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- Execution
-- InitialAccess
+  - Execution
+  - InitialAccess
 relevantTechniques:
-- T1204
-- T1204.001
-- T1566
-- T1566.002
+  - T1204
+  - T1204.001
+  - T1566
+  - T1566.002
 query: |
   let allowedDomains = dynamic(["microsoft.com","sentinel.blog", "ipinfo.io"]);
   let pattern = @"(https:\/\/[^\/]+)\/.*";
@@ -37,22 +39,22 @@ query: |
   | project TimeGenerated, DeviceName = toupper(DeviceName), UserPrincipalName = RecipientEmailAddress, InitiatingProcessAccountSid, ThreatType
   , InitiatingProcessFileName, InitiatingProcessFolderPath, RemoteUrl, Url, SenderFromDomain, SenderIPv4
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: Name
-    columnName: UserPrincipalName
-- entityType: URL
-  fieldMappings:
-  - identifier: Url
-    columnName: Url
-- entityType: Process
-  fieldMappings:
-  - identifier: CommandLine
-    columnName: InitiatingProcessFileName
-- entityType: Host
-  fieldMappings:
-  - identifier: HostName
-    columnName: DeviceName
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: UserPrincipalName
+  - entityType: URL
+    fieldMappings:
+      - identifier: Url
+        columnName: Url
+  - entityType: Process
+    fieldMappings:
+      - identifier: CommandLine
+        columnName: InitiatingProcessFileName
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: DeviceName
 eventGroupingSettings:
   aggregationKind: SingleAlert
 incidentConfiguration:
@@ -68,6 +70,6 @@ incidentConfiguration:
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Defender for Endpoint
+  - Sentinel-As-Code
+  - Custom
+  - Defender for Endpoint

--- a/Content/AnalyticalRules/DeviceTvmSoftwareVulnerabilities/VulnerabilityDetectedOnDomainController.yaml
+++ b/Content/AnalyticalRules/DeviceTvmSoftwareVulnerabilities/VulnerabilityDetectedOnDomainController.yaml
@@ -4,31 +4,31 @@ description: |
   'A Vulnerability was detected on a domain controller of either High or Critical and needs to be patched,'
 severity: High
 requiredDataConnectors:
-- connectorId: YourConnectorId
-  dataTypes:
-  - YourDataType
+  - connectorId: MicrosoftThreatProtection
+    dataTypes:
+      - DeviceTvmSoftwareVulnerabilities
 queryFrequency: PT5H
 queryPeriod: PT5H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- InitialAccess
-- Execution
+  - InitialAccess
+  - Execution
 relevantTechniques:
-- T1190
-- T1203
+  - T1190
+  - T1203
 query: |
   DeviceTvmSoftwareVulnerabilities
   | where DeviceName has_any("your-dc-hostname")
   and VulnerabilitySeverityLevel has_any ("High", "Critical")
 entityMappings:
-- entityType: Host
-  fieldMappings:
-  - identifier: HostName
-    columnName: DeviceName
-  - identifier: OSVersion
-    columnName: OSPlatform
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: DeviceName
+      - identifier: OSVersion
+        columnName: OSPlatform
 alertDetailsOverride:
   alertDynamicProperties: []
 eventGroupingSettings:
@@ -46,6 +46,6 @@ incidentConfiguration:
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Defender Vulnerability Management
+  - Sentinel-As-Code
+  - Custom
+  - Defender Vulnerability Management

--- a/Content/AnalyticalRules/M365Defender/BumblebeeMaliciousDllExportFunctionsDetectionRule.yaml
+++ b/Content/AnalyticalRules/M365Defender/BumblebeeMaliciousDllExportFunctionsDetectionRule.yaml
@@ -6,37 +6,37 @@ description: |
   Look for command line which contains malicious export functions as listed in query – this is a list of observed exports at time of writing and may change over time.'
 severity: High
 requiredDataConnectors:
-- connectorId: MicrosoftDefenderforEndpoints
-  dataTypes:
-  - DeviceFileEvents
-  - DeviceProcessEvents
+  - connectorId: MicrosoftDefenderforEndpoints
+    dataTypes:
+      - DeviceFileEvents
+      - DeviceProcessEvents
 queryFrequency: PT1H
 queryPeriod: PT1H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- Execution
-- Persistence
-- DefenseEvasion
-- LateralMovement
+  - Execution
+  - Persistence
+  - DefenseEvasion
+  - LateralMovement
 relevantTechniques:
-- T1059
-- T1059.003
-- T1211
-- T1554
-- T1569
-- T1569.002
-- T1574
-- T1574.002
+  - T1059
+  - T1059.003
+  - T1211
+  - T1554
+  - T1569
+  - T1569.002
+  - T1574
+  - T1574.002
 query: |
   union DeviceFileEvents, DeviceProcessEvents
   | where ProcessCommandLine has_any ("juwXYebIfE", "LeKGTMwkFQ", "dSjXqiVvQK", "SjVjlixjPb", "MDbJvVaNCR", "EPTsswwiRJ", "IternalJob", "YTBSBbNTWU", "AUjoZKdcSZ", "xshiMECwuG", "rBgTBiTTDW", "EUQtIMIQqE", "shjKeAQfgT", "zYKGjAgZov", "pGUAYVFxbN", "VcrbRMwpuk", "ZmJwfQQnqA", "zYKGjAgZov", "kXlNkCKgFC")
 entityMappings:
-- entityType: Process
-  fieldMappings:
-  - identifier: CommandLine
-    columnName: ProcessCommandLine
+  - entityType: Process
+    fieldMappings:
+      - identifier: CommandLine
+        columnName: ProcessCommandLine
 eventGroupingSettings:
   aggregationKind: SingleAlert
 incidentConfiguration:
@@ -52,6 +52,6 @@ incidentConfiguration:
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Microsoft Defender XDR
+  - Sentinel-As-Code
+  - Custom
+  - Microsoft Defender XDR

--- a/Content/AnalyticalRules/SecurityEvent/AdUserEnabledPasswordNotSet48hDetectionRule.yaml
+++ b/Content/AnalyticalRules/SecurityEvent/AdUserEnabledPasswordNotSet48hDetectionRule.yaml
@@ -8,24 +8,21 @@ description: |
   It is recommended that this time period is adjusted per your internal company policy.'
 severity: Low
 requiredDataConnectors:
-- connectorId: SecurityEvents
-  dataTypes:
-  - SecurityEvent
-- connectorId: WindowsSecurityEvents
-  dataTypes:
-  - SecurityEvent
+  - connectorId: WindowsSecurityEvents
+    dataTypes:
+      - SecurityEvent
 queryFrequency: P1D
 queryPeriod: P3D
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- Persistence
+  - Persistence
 relevantTechniques:
-- T1078
-- T1078.002
-- T1098
-- T1098.001
+  - T1078
+  - T1078.002
+  - T1098
+  - T1098.001
 query: |
   let starttime = 10d;
   let SecEvents = materialize ( SecurityEvent | where TimeGenerated >= ago(starttime)
@@ -49,19 +46,19 @@ query: |
   | extend timestamp = Time_Event4722, AccountCustomEntity = TargetAccount, HostCustomEntity = Computer_4722
   | project-reorder Time_Event4722, Time_Event4723, PasswordSetAttemptDelta_Min, TargetAccount, TargetSid
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: FullName
-    columnName: AccountCustomEntity
-  - identifier: Sid
-    columnName: TargetSid
-- entityType: Host
-  fieldMappings:
-  - identifier: FullName
-    columnName: HostCustomEntity
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+      - identifier: Sid
+        columnName: TargetSid
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
 version: 1.0.1
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Windows Security Events
+  - Sentinel-As-Code
+  - Custom
+  - Windows Security Events

--- a/Content/AnalyticalRules/SecurityEvent/NonDomainControllerAdReplicationDetectionRule.yaml
+++ b/Content/AnalyticalRules/SecurityEvent/NonDomainControllerAdReplicationDetectionRule.yaml
@@ -4,7 +4,7 @@ description: |
   'This query detects potential attempts by non-computer accounts (non domain controllers) to retrieve/synchronize an active directory object leveraging directory replication services (DRS).'
 severity: High
 requiredDataConnectors:
-- connectorId: SecurityEvent
+- connectorId: WindowsSecurityEvents
   dataTypes:
   - SecurityEvent
 queryFrequency: P1D

--- a/Content/AnalyticalRules/SecurityEvent/SecurityEventLogClearedDetectionRule.yaml
+++ b/Content/AnalyticalRules/SecurityEvent/SecurityEventLogClearedDetectionRule.yaml
@@ -1,22 +1,23 @@
 id: aed11b0b-c1a0-4ea5-9d33-2e02f06f5bdc
 name: Security Event Log Cleared
-description: "'Identifies when event logs are cleared on monitored systems. It queries for events with Event ID 1102, which indicates that event logs have been cleared. \nThe rule runs on a 24-hour schedule,\
-  \ scanning the past 24 hours of log data for any instances of cleared event logs. If such an event is detected, it will generate an incident for investigation and potential response actions'\n"
+description: |
+  'Identifies when event logs are cleared on monitored systems. It queries for events with Event ID 1102, which indicates that event logs have been cleared. 
+  The rule runs on a 24-hour schedule, scanning the past 24 hours of log data for any instances of cleared event logs. If such an event is detected, it will generate an incident for investigation and potential response actions'
 severity: High
 requiredDataConnectors:
-- connectorId: SecurityEvent
-  dataTypes:
-  - SecurityEvent
+  - connectorId: WindowsSecurityEvents
+    dataTypes:
+      - SecurityEvent
 queryFrequency: P1D
 queryPeriod: P1D
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- DefenseEvasion
+  - DefenseEvasion
 relevantTechniques:
-- T1070
-- T1070.001
+  - T1070
+  - T1070.001
 query: |
   SecurityEvent
   | where TimeGenerated > ago(24h)
@@ -25,17 +26,17 @@ query: |
   //The EventID for Event Log Clearing is 1102
   | project TimeGenerated, Account, AccountType,Computer, EventID, TargetAccount, TargetUserName
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: Name
-    columnName: Account
-- entityType: Host
-  fieldMappings:
-  - identifier: HostName
-    columnName: Computer
+  - entityType: Account
+    fieldMappings:
+      - identifier: Name
+        columnName: Account
+  - entityType: Host
+    fieldMappings:
+      - identifier: HostName
+        columnName: Computer
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Windows Security Events
+  - Sentinel-As-Code
+  - Custom
+  - Windows Security Events

--- a/Content/AnalyticalRules/SecurityEvent/UserAccountPrivilegedGroupAdditionDetectionRule.yaml
+++ b/Content/AnalyticalRules/SecurityEvent/UserAccountPrivilegedGroupAdditionDetectionRule.yaml
@@ -5,39 +5,51 @@ description: |
   such as the Enterprise Admins, Cert Publishers or DnsAdmins. Be sure to verify this is an expected addition.
 severity: Medium
 requiredDataConnectors:
-- connectorId: SecurityEvents
-  dataTypes:
-  - SecurityEvent
+  - connectorId: WindowsSecurityEvents
+    dataTypes:
+      - SecurityEvent
 queryFrequency: PT1H
 queryPeriod: PT1H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- Persistence
-- PrivilegeEscalation
+  - Persistence
+  - PrivilegeEscalation
 relevantTechniques:
-- T1078
-- T1078.002
-- T1098
-- T1098.003
-query: "let timeframe = 40d;\n// For AD SID mappings - https://docs.microsoft.com/windows/security/identity-protection/access-control/active-directory-security-groups\nlet WellKnownLocalSID = \"S-1-5-32-5[0-9][0-9]$\"\
-  ;\nlet WellKnownGroupSID = \"S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000$\"\
-  ;\nSecurityEvent \n| where TimeGenerated > ago(timeframe)\n// When MemberName contains '-' this indicates addition of a group to a group\n| where AccountType == \"User\" and MemberName != \"-\"\n// 4728\
-  \ - A member was added to a security-enabled global group\n// 4732 - A member was added to a security-enabled local group\n// 4756 - A member was added to a security-enabled universal group\n| where EventID\
-  \ in (4728, 4732, 4756)   \n| where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID\n// Exclude Remote Desktop Users group: S-1-5-32-555\n| where TargetSid !in (\"\
-  S-1-5-32-555\")\n| where TargetSid != (\"S-1-5-32-545\")\n| extend SimpleMemberName = tostring(split(tostring(split(MemberName, \",\")[0]),\"CN=\")[1])\n| project StartTimeUtc = TimeGenerated, EventID,\
-  \ Activity, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid\n| extend timestamp = StartTimeUtc, AccountCustomEntity\
-  \ = SimpleMemberName, HostCustomEntity = Computer\n"
+  - T1078
+  - T1078.002
+  - T1098
+  - T1098.003
+query: |
+  let timeframe = 40d;
+  // For AD SID mappings - https://docs.microsoft.com/windows/security/identity-protection/access-control/active-directory-security-groups
+  let WellKnownLocalSID = "S-1-5-32-5[0-9][0-9]$";
+  let WellKnownGroupSID = "S-1-5-21-[0-9]*-[0-9]*-[0-9]*-5[0-9][0-9]$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1102$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1103$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-498$|S-1-5-21-[0-9]*-[0-9]*-[0-9]*-1000$";
+  SecurityEvent 
+  | where TimeGenerated > ago(timeframe)
+  // When MemberName contains '-' this indicates addition of a group to a group
+  | where AccountType == "User" and MemberName != "-"
+  // 4728 - A member was added to a security-enabled global group
+  // 4732 - A member was added to a security-enabled local group
+  // 4756 - A member was added to a security-enabled universal group
+  | where EventID in (4728, 4732, 4756)   
+  | where TargetSid matches regex WellKnownLocalSID or TargetSid matches regex WellKnownGroupSID
+  // Exclude Remote Desktop Users group: S-1-5-32-555
+  | where TargetSid !in ("S-1-5-32-555")
+  | where TargetSid != ("S-1-5-32-545")
+  | extend SimpleMemberName = tostring(split(tostring(split(MemberName, ",")[0]),"CN=")[1])
+  | project StartTimeUtc = TimeGenerated, EventID, Activity, Computer, SimpleMemberName, MemberName, MemberSid, TargetUserName, TargetDomainName, TargetSid, UserPrincipalName, SubjectUserName, SubjectUserSid
+  | extend timestamp = StartTimeUtc, AccountCustomEntity = SimpleMemberName, HostCustomEntity = Computer
 entityMappings:
-- entityType: Account
-  fieldMappings:
-  - identifier: FullName
-    columnName: AccountCustomEntity
-- entityType: Host
-  fieldMappings:
-  - identifier: FullName
-    columnName: HostCustomEntity
+  - entityType: Account
+    fieldMappings:
+      - identifier: FullName
+        columnName: AccountCustomEntity
+  - entityType: Host
+    fieldMappings:
+      - identifier: FullName
+        columnName: HostCustomEntity
 eventGroupingSettings:
   aggregationKind: SingleAlert
 incidentConfiguration:
@@ -53,6 +65,6 @@ incidentConfiguration:
 version: 1.0.1
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Windows Security Events
+  - Sentinel-As-Code
+  - Custom
+  - Windows Security Events

--- a/Content/AnalyticalRules/Usage/DataIngestionAboveAverageForLast14d.yaml
+++ b/Content/AnalyticalRules/Usage/DataIngestionAboveAverageForLast14d.yaml
@@ -4,36 +4,67 @@ description: |
   'Enter rule description here'
 severity: Informational
 requiredDataConnectors:
-- connectorId: YourConnectorId
-  dataTypes:
-  - YourDataType
+  - connectorId: YourConnectorId
+    dataTypes:
+      - YourDataType
 queryFrequency: PT5H
 queryPeriod: PT5H
 triggerOperator: gt
 triggerThreshold: 0
 enabled: true
 tactics:
-- DefenseEvasion
-- Impact
-query: "let lastWeekStart = ago(14d); \nlet lastWeekEnd = ago(7d); \nlet thisWeekStart = ago(7d); \nlet thisWeekEnd = ago(0d); \nUsage\n| where IsBillable == true\n| where TimeGenerated >= lastWeekStart\
-  \ and TimeGenerated < lastWeekEnd \n| summarize LastWeekSize = sumif(Quantity, isnotempty(DataType)) / round(1024,-3) by DataType \n| union (\n    Usage\n    | where IsBillable == true\n    | where TimeGenerated\
-  \ >= thisWeekStart and TimeGenerated < thisWeekEnd \n    | summarize DataTypes = make_set(DataType)\n    | mv-expand DataTypes\n    | where DataTypes !in (( \n        Usage\n        | where IsBillable\
-  \ == true\n        | where TimeGenerated >= lastWeekStart and TimeGenerated < lastWeekEnd \n        | summarize DataTypes = make_set(DataType)\n        | mv-expand DataTypes\n    ))\n    | project DataType\
-  \ = DataTypes, LastWeekSize = 0\n)\n| extend DataType = strcat(DataType_string, DataType_dynamic)\n| join kind=leftouter (\n    Usage\n    | where IsBillable == true\n    | where TimeGenerated >= thisWeekStart\
-  \ and TimeGenerated < thisWeekEnd \n    | summarize ThisWeekSize = sumif(Quantity, isnotempty(DataType)) / round(1024,-3) by DataType \n) on DataType\n| extend LastWeekSize = toreal(strcat(LastWeekSize_long,\
-  \ LastWeekSize_real))\n| project DataType, LastWeekSize = round(toreal(LastWeekSize), 5), ThisWeekSize = round(toreal(ThisWeekSize), 5),\n    ['Size Change %'] = \n        case(\n            LastWeekSize\
-  \ == 0 and ThisWeekSize > 0, \n            toreal(100), // 100% increase if LastWeekSize was 0 and ThisWeekSize is greater than 0\n            LastWeekSize > 0 and ThisWeekSize / LastWeekSize > 10, \n\
-  \            toreal(100), // Cap at 1000% if the change is more than 10 times\n            round((ThisWeekSize - LastWeekSize) / LastWeekSize * 100, 0)\n        ) \n| order by abs(['Size Change %']) desc\n\
-  | where ['Size Change %'] > 50\n"
+  - DefenseEvasion
+  - Impact
+query: |
+  let lastWeekStart = ago(14d); 
+  let lastWeekEnd = ago(7d); 
+  let thisWeekStart = ago(7d); 
+  let thisWeekEnd = ago(0d); 
+  Usage
+  | where IsBillable == true
+  | where TimeGenerated >= lastWeekStart and TimeGenerated < lastWeekEnd 
+  | summarize LastWeekSize = sumif(Quantity, isnotempty(DataType)) / round(1024,-3) by DataType 
+  | union (
+      Usage
+      | where IsBillable == true
+      | where TimeGenerated >= thisWeekStart and TimeGenerated < thisWeekEnd 
+      | summarize DataTypes = make_set(DataType)
+      | mv-expand DataTypes
+      | where DataTypes !in (( 
+          Usage
+          | where IsBillable == true
+          | where TimeGenerated >= lastWeekStart and TimeGenerated < lastWeekEnd 
+          | summarize DataTypes = make_set(DataType)
+          | mv-expand DataTypes
+      ))
+      | project DataType = DataTypes, LastWeekSize = 0
+  )
+  | extend DataType = strcat(DataType_string, DataType_dynamic)
+  | join kind=leftouter (
+      Usage
+      | where IsBillable == true
+      | where TimeGenerated >= thisWeekStart and TimeGenerated < thisWeekEnd 
+      | summarize ThisWeekSize = sumif(Quantity, isnotempty(DataType)) / round(1024,-3) by DataType 
+  ) on DataType
+  | extend LastWeekSize = toreal(strcat(LastWeekSize_long, LastWeekSize_real))
+  | project DataType, LastWeekSize = round(toreal(LastWeekSize), 5), ThisWeekSize = round(toreal(ThisWeekSize), 5),
+      ['Size Change %'] = 
+          case(
+              LastWeekSize == 0 and ThisWeekSize > 0, 
+              toreal(100), // 100% increase if LastWeekSize was 0 and ThisWeekSize is greater than 0
+              LastWeekSize > 0 and ThisWeekSize / LastWeekSize > 10, 
+              toreal(100), // Cap at 1000% if the change is more than 10 times
+              round((ThisWeekSize - LastWeekSize) / LastWeekSize * 100, 0)
+          ) 
+  | order by abs(['Size Change %']) desc
+  | where ['Size Change %'] > 50
 entityMappings:
-- entityType: CloudApplication
-  fieldMappings:
-  - identifier: Name
-    columnName: DataType
+  - entityType: CloudApplication
+    fieldMappings:
+      - identifier: Name
+        columnName: DataType
 eventGroupingSettings:
   aggregationKind: SingleAlert
-suppressionEnabled: true
-suppressionDuration: P1D
 incidentConfiguration:
   createIncident: true
   groupingConfiguration:
@@ -44,9 +75,11 @@ incidentConfiguration:
     groupByEntities: []
     groupByAlertDetails: []
     groupByCustomDetails: []
+suppressionDuration: P1D
+suppressionEnabled: true
 version: 1.0.0
 kind: Scheduled
 tags:
-- Sentinel-As-Code
-- Custom
-- Workspace Usage
+  - Sentinel-As-Code
+  - Custom
+  - Workspace Usage


### PR DESCRIPTION
## Summary

Corrects `requiredDataConnectors` metadata on 14 analytical rules and reformats
the 16 touched YAML files. No detection logic changes.

## Why is this change needed?

Fourteen rules declared connector metadata that was wrong in one of four ways: a
placeholder left over from authoring (`YourConnectorId` / `YourDataType`), an
empty connector block, a connector ID that does not exist, or a data type the
named connector does not emit.

This fails quietly. Nothing breaks at deploy time, so the errors survive. But the
metadata feeds Content Hub solution mapping and the dependency-impact scoring in
`Invoke-TableMigrationReview.ps1`, so wrong values there produce wrong answers in
an assessment someone is relying on to plan a migration.

## What does this change do?

**Placeholders replaced:**

| Rule | New connector : data types |
| --- | --- |
| `PotentialTorExitNodeDetected` | `AzureActivity:AzureActivity` |
| `ChangeWasMadeToTailscale` | `TailscaleCCF:TailscaleAudit_CL` |
| `PotentialExploitationOfCve202449112LdapNightmare` | `ASimDnsActivityLogs:ASimDnsActivityLogs` |
| `SmartScreenPotentialPhishingUrlClicked` | `MicrosoftThreatProtection:EmailEvents\|EmailUrlInfo\|DeviceEvents` |
| `VulnerabilityDetectedOnDomainController` | `MicrosoftThreatProtection:DeviceTvmSoftwareVulnerabilities` |

**Empty connector blocks populated:**

| Rule | New connector : data types |
| --- | --- |
| `AwsGuarddutyAlertDetectionRule` | `AwsS3ServerAccessLogsDefinition:AWSGuardDuty` |
| `TokenReplayWorkloadIdentityOutsideAzureDetectionRule` | `AzureActivity:AzureActivity` |

**Wrong data type for the declared connector:**

| Rule | Change |
| --- | --- |
| `NewDataConnectorDeploymentDetectionRule` | `AuditLogs` -> `AzureActivity` |
| `NewDcrCreationDetectionRule` | `AuditLogs` -> `AzureActivity` |

**Non-existent or duplicated connector IDs**, consolidated onto the real
`WindowsSecurityEvents` connector:

| Rule | Change |
| --- | --- |
| `AdUserEnabledPasswordNotSet48hDetectionRule` | duplicate `SecurityEvents` + `WindowsSecurityEvents` pair collapsed to one entry |
| `NonDomainControllerAdReplicationDetectionRule` | `SecurityEvent` -> `WindowsSecurityEvents` |
| `SecurityEventLogClearedDetectionRule` | `SecurityEvent` -> `WindowsSecurityEvents` |
| `UserAccountPrivilegedGroupAdditionDetectionRule` | `SecurityEvents` -> `WindowsSecurityEvents` |

**Data types reordered only:** `AzureFirewallMultipleDenyActionsDetectionRule`.

**Reformatting** applies to all 16 touched files and accounts for most of the
diff volume: the `query` moves from an escaped single-line folded scalar to a
literal block scalar (`query: |`), sequences take two-space indentation, and the
suppression keys sit after `incidentConfiguration`. The block scalar is the
material improvement here, since the folded form made the KQL close to unreadable
in review.

## Type of change

- [ ] New detection content (analytical rule, hunting query, Defender detection)
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Refactor

## Testing

- **Query equivalence proven, not assumed.** Each changed rule's `query` field
  was parsed from both `HEAD` and the working copy and compared with whitespace
  normalised. All 16 are semantically identical, so the reformat carries no
  detection change.
- `Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1`: **3452 passed,
  0 failed, 322 skipped**.
- `Build-DependencyManifest.ps1 -Mode Verify`: manifest matches discovered
  dependencies across 260 content items, so `dependencies.json` needs no
  regeneration and the `dependency-manifest` gate should stay green.

## Notes for the reviewer

The reformat inflates the diff. If it helps, review with `git diff -w` or check
the query fields against the equivalence result above and focus attention on the
`requiredDataConnectors` blocks, which are the only semantic change.

**Known remaining work, deliberately out of scope:** 16 other rules still carry
`YourConnectorId` / `YourDataType` placeholders, mostly the Usage and
data-ingestion family (`DataIngestionAnomalyDetectionRule`,
`DataIngestionDropDetectionRule`, `NewDataConnectorDeployed`,
`NewDcrCreated`, `TokenTheftDetectionUnboundSessionsOnUnmanagedDevices` and
others). Two of them, `DataIngestionAboveAverageForLast14d` and
`BumblebeeMaliciousDllExportFunctionsDetectionRule`, are reformatted in this PR
but keep their placeholders. Worth a follow-up pass.
