### PR TITLE
chore(scripts): consolidate PowerShell file headers into comment-based help

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,11 +66,15 @@ Start any unfamiliar task by reading [`Docs/README.md`](../Docs/README.md).
 
 ### File headers
 
-**PowerShell** files carry their metadata in the comment-based help
-block (`<# ... #>`) only. Do not add a separate `#`-comment banner
-above it - the path, author and dates live in `.NOTES`:
+**PowerShell** files open with their `#Requires` statements, then a
+comment-based help block, and nothing else above either. Do not add a
+separate `#`-comment banner - the path, author and dates live in
+`.NOTES`:
 
 ```powershell
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts
+
 <#
 .SYNOPSIS
     One-line summary.
@@ -79,14 +83,18 @@ above it - the path, author and dates live in `.NOTES`:
     File:         Deploy/Foo.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      YYYY-MM-DD
     Version:      0.1.0
     Last Updated: YYYY-MM-DD
+    Requires:     PowerShell 7.2+, Az.Accounts
 #>
 ```
 
-Full shape (including `.DESCRIPTION`, `.PARAMETER` and `.EXAMPLE`) is
-in [`instructions/powershell-scripts.instructions.md`](instructions/powershell-scripts.instructions.md).
+All eight `.NOTES` keys are required, in that order, with `Requires:`
+last. Full shape (including `.DESCRIPTION`, `.PARAMETER`, `.EXAMPLE`,
+the `API versions:` block and `.LINK` references) is in
+[`instructions/powershell-scripts.instructions.md`](instructions/powershell-scripts.instructions.md).
 
 For YAML / JSON files where a comment header isn't natural (e.g. data
 files), skip the header - but for hand-authored content like analytical

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,20 +66,30 @@ Start any unfamiliar task by reading [`Docs/README.md`](../Docs/README.md).
 
 ### File headers
 
-Every new PowerShell / Bicep / YAML / JSON file should carry a header
-that includes the full repo-relative path and a creation date in
-DD/MM/YYYY format. Example:
+**PowerShell** files carry their metadata in the comment-based help
+block (`<# ... #>`) only. Do not add a separate `#`-comment banner
+above it - the path, author and dates live in `.NOTES`:
 
 ```powershell
-#
-# Sentinel-As-Code/Deploy/Foo.ps1
-#
-# Created by <author> on DD/MM/YYYY.
-#
+<#
+.SYNOPSIS
+    One-line summary.
+
+.NOTES
+    File:         Deploy/Foo.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      YYYY-MM-DD
+    Version:      0.1.0
+    Last Updated: YYYY-MM-DD
+#>
 ```
 
+Full shape (including `.DESCRIPTION`, `.PARAMETER` and `.EXAMPLE`) is
+in [`instructions/powershell-scripts.instructions.md`](instructions/powershell-scripts.instructions.md).
+
 For YAML / JSON files where a comment header isn't natural (e.g. data
-files), skip the header — but for hand-authored content like analytical
+files), skip the header - but for hand-authored content like analytical
 rules, include a brief metadata block at the top of the file.
 
 ### Commit messages

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -24,24 +24,36 @@ the existing repo style. Reference doc:
 ## File header (required for every file)
 
 Every `.ps1` and `.psm1` file starts with a comment-based help block
-and **nothing above it**. There is no separate `#`-comment banner -
-the repo-relative path, author and dates belong in `.NOTES`:
+and **nothing above it** except `#Requires` statements. There is no
+separate `#`-comment banner - the repo-relative path, author and dates
+belong in `.NOTES`.
+
+Keywords always appear in this order, one blank line between each:
 
 ```powershell
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
-    One-line summary.
+    One sentence, no full stop needed. What the file does, not how.
 
 .DESCRIPTION
-    Multi-paragraph description: what does this script do, when
-    should I run it, what does it produce?
+    Multi-paragraph prose: what it does, when to run it, what it
+    produces, and any behaviour a reader would otherwise have to
+    infer from the code. Wrap at roughly 75 characters.
 
 .PARAMETER ParamName
-    Per-parameter description.
+    One entry per parameter in the param block, in declaration order.
+    Say what it controls and what happens when it is omitted.
+
+.OUTPUTS
+    Optional. The type emitted to the pipeline, and what it carries.
 
 .EXAMPLE
     ./Deploy/Foo.ps1 -ParamName Value
-    Brief description of what the example does.
+
+    A blank line, then prose explaining what this invocation does and
+    when you would reach for it.
 
 .NOTES
     File:         Deploy/Foo.ps1
@@ -50,28 +62,47 @@ the repo-relative path, author and dates belong in `.NOTES`:
     Created:      YYYY-MM-DD
     Version:      0.1.0
     Last Updated: YYYY-MM-DD
-    Requires:     PowerShell 7.2+, Az.Accounts (etc.)
+    Requires:     PowerShell 7.2+, Az.Accounts
+
+    Any free-form notes go here, after a blank line, never welded
+    onto the end of the metadata keys.
+
+.LINK
+    Optional. One URL per entry.
 #>
 ```
 
-Field rules:
+Field rules for `.NOTES`:
 
-- **`File:`** - repo-relative path with no leading `./`. Keep it
-  accurate when a file moves.
+- The six metadata keys come first, in the order shown, values
+  aligned to a single column. `Requires:` follows them when present.
+- **`File:`** - repo-relative path with no leading `./` and no
+  `Sentinel-As-Code/` prefix. Keep it accurate when a file moves.
 - **`Repository:`** - always `Sentinel-As-Code`.
 - **`Author:`** - `noodlemctwoodle` unless the file was contributed
   by someone else, in which case credit them.
-- **`Created:`** / **`Last Updated:`** - ISO `YYYY-MM-DD`, matching the
-  format the existing `.NOTES` blocks already use.
+- **`Created:`** / **`Last Updated:`** - ISO `YYYY-MM-DD`.
 - **`Version:`** - semver. New files start at `0.1.0`. Bump on change.
-- **`Requires:`** - optional; list PowerShell floor and PSGallery deps.
+- **Free-form prose** (provenance, RBAC needs, API versions, data
+  sources) is allowed, but must be separated from the keys by a blank
+  line so the metadata block stays scannable.
 
-`.psd1` manifests are data files (`@{ ... }`) and carry no
+### Variants
+
+**Files that define functions rather than run** (`Modules/**/*.psm1`,
+`Tools/Documenter/Private/*.ps1`): the file-level block describes the
+file and carries `.NOTES`. Per-parameter and per-example detail lives
+on each function's own help block, not the file's.
+
+**Pester test files** (`Tests/**/*.Tests.ps1`): no `.PARAMETER`, since
+they take none. `.EXAMPLE` carries the `Invoke-Pester` invocations a
+reader would actually run - the full file, a focused `-FullName`
+subset, and detailed output where useful. Prerequisites go in
+`.NOTES` prose.
+
+**`.psd1` manifests** are data files (`@{ ... }`) and carry no
 comment-based help. Their metadata lives in the manifest keys
 (`Author`, `ModuleVersion`, `Description`) instead.
-
-Pester test files under `Tests/` follow the same rule, minus
-`.PARAMETER` / `.EXAMPLE`, which rarely apply.
 
 ## Use the Sentinel.Common module
 

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -130,16 +130,23 @@ second `#Requires` after the `param()` block is redundant, since the
 one at the top already gates the whole file, and it drifts out of step
 with the header the moment either is edited.
 
-Two things must never appear in `#Requires -Modules`. The statement
+Three things must never appear in `#Requires -Modules`. The statement
 resolves against `PSModulePath` and fails the load outright when it
-cannot, so naming either of these breaks the file for everyone:
+cannot, so naming any of these breaks the file for everyone:
 
 - **`Sentinel.Common`**, which is imported by path, not installed.
 - **CLI tooling** (Azure CLI, git, pandoc, Node) which is not a
   PowerShell module at all.
+- **Anything the file installs itself.** Several scripts and suites
+  call `Install-Module powershell-yaml` when it is missing.
+  `#Requires` aborts the load before the first line of the file runs,
+  so gating on a module the file was going to fetch makes the fetch
+  unreachable and turns a self-healing script into a hard failure.
 
-Both still belong in `Requires:`, where they are documentation rather
-than a gate.
+All three still belong in `Requires:`, where they are documentation
+rather than a gate. Mark the self-installing ones
+`(auto-installed if missing)` so the distinction is visible without
+reading the code.
 
 Remember that `#Requires` is enforced when a file is run, dot-sourced
 or imported, not when it is parsed. Most scripts here are only

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -23,10 +23,11 @@ the existing repo style. Reference doc:
 
 ## File header (required for every file)
 
-Every `.ps1` and `.psm1` file starts with a comment-based help block
-and **nothing above it** except `#Requires` statements. There is no
-separate `#`-comment banner - the repo-relative path, author and dates
-belong in `.NOTES`.
+Every `.ps1` and `.psm1` file opens with its `#Requires` statements,
+then a comment-based help block, and nothing else above either. There
+is no separate `#`-comment banner - the repo-relative path, author and
+dates belong in `.NOTES`. See "#Requires statements" below for what may
+and may not be enforced there.
 
 Keywords always appear in this order, one blank line between each:
 

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -65,6 +65,9 @@ Keywords always appear in this order, one blank line between each:
     Last Updated: YYYY-MM-DD
     Requires:     PowerShell 7.2+, Az.Accounts
 
+    API versions:
+      - Sentinel : 2025-09-01 (GA)
+
     Any free-form notes go here, after a blank line, never welded
     onto the end of the metadata keys.
 
@@ -77,8 +80,7 @@ Field rules for `.NOTES`:
 
 - Every file carries the same eight keys, in the order shown, values
   aligned to a single column. Optional extras (`Component:`,
-  `API Version:`, `Permissions:`) sit between `Last Updated:` and
-  `Requires:`.
+  `Permissions:`) sit between `Last Updated:` and `Requires:`.
 - **`File:`** - repo-relative path with no leading `./` and no
   `Sentinel-As-Code/` prefix. Keep it accurate when a file moves.
 - **`Repository:`** - always `Sentinel-As-Code`.
@@ -94,9 +96,53 @@ Field rules for `.NOTES`:
   `Requires:` is the human-readable summary of it. Adding a
   `Requires:` line does not license adding a `#Requires` statement -
   those change whether the file will load at all.
-- **Free-form prose** (provenance, RBAC needs, API versions, data
-  sources) is allowed, but must be separated from the keys by a blank
-  line so the metadata block stays scannable.
+- **`API Version:`** is not a key. API versions go in a prose block, see
+  "API versions" below.
+- **Free-form prose** (provenance, RBAC needs, data sources) is
+  allowed, but must be separated from the keys by a blank line so the
+  metadata block stays scannable.
+
+### API versions
+
+Any file that calls an Azure or Graph API records every version it
+pins, in a labelled block after the metadata keys. One line per API,
+colons aligned, with a parenthetical where the choice of version is
+not obvious:
+
+```powershell
+    API versions:
+      - Log Analytics tables  : 2023-09-01
+      - Data collection rules : 2023-03-11 (the version that added
+                                'endpoints', so Direct DCRs authored here
+                                receive a built-in logsIngestion endpoint)
+```
+
+A single-line `API Version: a, b, c` key is not the convention. The
+block form leaves room to say *why* a version was chosen, which is the
+part a reader cannot recover from the code.
+
+Helpers that take their version from the caller say so rather than
+inventing one. Test files need no block: asserting on a version string
+is not calling an API.
+
+### References
+
+Any file that implements a documented Azure or Graph API contract
+carries a `.LINK` entry pointing at the Microsoft Learn reference for
+it, one URL per entry, after `.NOTES`. Link the REST reference for the
+API being called, not a conceptual overview, so a reader can check the
+request shape directly:
+
+```powershell
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
+
+.LINK
+    https://learn.microsoft.com/rest/api/application-insights/workbooks
+```
+
+Verify a URL resolves before committing it. A dead reference is worse
+than no reference, because it implies the contract was checked.
 
 ### Variants
 

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -59,6 +59,7 @@ Keywords always appear in this order, one blank line between each:
     File:         Deploy/Foo.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      YYYY-MM-DD
     Version:      0.1.0
     Last Updated: YYYY-MM-DD
@@ -74,15 +75,25 @@ Keywords always appear in this order, one blank line between each:
 
 Field rules for `.NOTES`:
 
-- The six metadata keys come first, in the order shown, values
-  aligned to a single column. `Requires:` follows them when present.
+- Every file carries the same eight keys, in the order shown, values
+  aligned to a single column. Optional extras (`Component:`,
+  `API Version:`, `Permissions:`) sit between `Last Updated:` and
+  `Requires:`.
 - **`File:`** - repo-relative path with no leading `./` and no
   `Sentinel-As-Code/` prefix. Keep it accurate when a file moves.
 - **`Repository:`** - always `Sentinel-As-Code`.
 - **`Author:`** - `noodlemctwoodle` unless the file was contributed
   by someone else, in which case credit them.
+- **`Website:`** - always `https://sentinel.blog`.
 - **`Created:`** / **`Last Updated:`** - ISO `YYYY-MM-DD`.
 - **`Version:`** - semver. New files start at `0.1.0`. Bump on change.
+- **`Requires:`** - mandatory, always the last key, always one line.
+  Name the PowerShell floor first, then modules and external tooling.
+  Where the file also carries `#Requires` statements, this line must
+  name everything they enforce. `#Requires` is the functional gate;
+  `Requires:` is the human-readable summary of it. Adding a
+  `Requires:` line does not license adding a `#Requires` statement -
+  those change whether the file will load at all.
 - **Free-form prose** (provenance, RBAC needs, API versions, data
   sources) is allowed, but must be separated from the keys by a blank
   line so the metadata block stays scannable.

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -91,16 +91,50 @@ Field rules for `.NOTES`:
 - **`Version:`** - semver. New files start at `0.1.0`. Bump on change.
 - **`Requires:`** - mandatory, always the last key, always one line.
   Name the PowerShell floor first, then modules and external tooling.
-  Where the file also carries `#Requires` statements, this line must
-  name everything they enforce. `#Requires` is the functional gate;
-  `Requires:` is the human-readable summary of it. Adding a
-  `Requires:` line does not license adding a `#Requires` statement -
-  those change whether the file will load at all.
+  It must stay in step with the file's `#Requires` statements in both
+  directions: `#Requires` is the functional gate, `Requires:` is the
+  human-readable summary, and neither may name something the other
+  omits. See "#Requires statements" below.
 - **`API Version:`** is not a key. API versions go in a prose block, see
   "API versions" below.
 - **Free-form prose** (provenance, RBAC needs, data sources) is
   allowed, but must be separated from the keys by a blank line so the
   metadata block stays scannable.
+
+### #Requires statements
+
+Every file declares its PowerShell floor and its PSGallery module
+dependencies as `#Requires` statements, above the help block and with
+nothing else before them:
+
+```powershell
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources
+
+<#
+.SYNOPSIS
+    ...
+```
+
+`-Version` first, then `-Modules`, then a blank line.
+
+Two things must never appear in `#Requires -Modules`. The statement
+resolves against `PSModulePath` and fails the load outright when it
+cannot, so naming either of these breaks the file for everyone:
+
+- **`Sentinel.Common`**, which is imported by path, not installed.
+- **CLI tooling** (Azure CLI, git, pandoc, Node) which is not a
+  PowerShell module at all.
+
+Both still belong in `Requires:`, where they are documentation rather
+than a gate.
+
+Remember that `#Requires` is enforced when a file is run, dot-sourced
+or imported, not when it is parsed. Most scripts here are only
+AST-parsed by their test suite, so a module requirement never loads.
+The exceptions are the files a test dot-sources or imports directly,
+where an unavailable module fails the suite. Check before adding a
+module that CI does not install.
 
 ### API versions
 

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -119,6 +119,15 @@ nothing else before them:
 
 `-Version` first, then `-Modules`, then a blank line.
 
+`#Requires -Version 7.2` is not optional and not negotiable down: the
+repo floor is 7.2, matching `Sentinel.Common.psd1`, so every file
+declares it even when it needs no modules at all.
+
+Both statements belong at the top of the file and nowhere else. A
+second `#Requires` after the `param()` block is redundant, since the
+one at the top already gates the whole file, and it drifts out of step
+with the header the moment either is edited.
+
 Two things must never appear in `#Requires -Modules`. The statement
 resolves against `PSModulePath` and fails the load outright when it
 cannot, so naming either of these breaks the file for everyone:

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -21,15 +21,13 @@ the existing repo style. Reference doc:
 - **`$ErrorActionPreference = 'Stop'`** at the top of every script
   and module. Errors should fail loud, not be silently swallowed.
 
-## File header (required for new files)
+## File header (required for every file)
+
+Every `.ps1` and `.psm1` file starts with a comment-based help block
+and **nothing above it**. There is no separate `#`-comment banner -
+the repo-relative path, author and dates belong in `.NOTES`:
 
 ```powershell
-#
-# Sentinel-As-Code/Deploy/<Name>.ps1
-#
-# Created by <author> on DD/MM/YYYY.
-#
-
 <#
 .SYNOPSIS
     One-line summary.
@@ -46,13 +44,34 @@ the existing repo style. Reference doc:
     Brief description of what the example does.
 
 .NOTES
-    Author:       <author>
-    Version:      <semver>
-    Last Updated: YYYY-MM-DD
+    File:         Deploy/Foo.ps1
     Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      YYYY-MM-DD
+    Version:      0.1.0
+    Last Updated: YYYY-MM-DD
     Requires:     PowerShell 7.2+, Az.Accounts (etc.)
 #>
 ```
+
+Field rules:
+
+- **`File:`** - repo-relative path with no leading `./`. Keep it
+  accurate when a file moves.
+- **`Repository:`** - always `Sentinel-As-Code`.
+- **`Author:`** - `noodlemctwoodle` unless the file was contributed
+  by someone else, in which case credit them.
+- **`Created:`** / **`Last Updated:`** - ISO `YYYY-MM-DD`, matching the
+  format the existing `.NOTES` blocks already use.
+- **`Version:`** - semver. New files start at `0.1.0`. Bump on change.
+- **`Requires:`** - optional; list PowerShell floor and PSGallery deps.
+
+`.psd1` manifests are data files (`@{ ... }`) and carry no
+comment-based help. Their metadata lives in the manifest keys
+(`Author`, `ModuleVersion`, `Description`) instead.
+
+Pester test files under `Tests/` follow the same rule, minus
+`.PARAMETER` / `.EXAMPLE`, which rarely apply.
 
 ## Use the Sentinel.Common module
 

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -121,6 +121,19 @@ nothing else before them:
 directive `#Requires`, capital R. PowerShell accepts any casing, but a
 mixed-case corpus makes the statement harder to grep for.
 
+Each keyword needs its own statement, so the prologue is always at
+least two lines. Every module goes on the single `-Modules` line
+though, comma-separated. The value takes a mix of plain names and
+version hashtables:
+
+```powershell
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }, Az.Accounts
+```
+
+Repeated `#Requires -Modules` lines are legal, and PowerShell unions
+them, but they give the same declaration two places to live and drift
+apart in.
+
 `#Requires -Version 7.2` is not optional and not negotiable down: the
 repo floor is 7.2, matching `Sentinel.Common.psd1`, so every file
 declares it even when it needs no modules at all.

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -117,7 +117,9 @@ nothing else before them:
     ...
 ```
 
-`-Version` first, then `-Modules`, then a blank line.
+`-Version` first, then `-Modules`, then a blank line. Spell the
+directive `#Requires`, capital R. PowerShell accepts any casing, but a
+mixed-case corpus makes the statement harder to grep for.
 
 `#Requires -Version 7.2` is not optional and not negotiable down: the
 repo floor is 7.2, matching `Sentinel.Common.psd1`, so every file

--- a/.github/instructions/powershell-scripts.instructions.md
+++ b/.github/instructions/powershell-scripts.instructions.md
@@ -121,10 +121,11 @@ nothing else before them:
 directive `#Requires`, capital R. PowerShell accepts any casing, but a
 mixed-case corpus makes the statement harder to grep for.
 
-Each keyword needs its own statement, so the prologue is always at
-least two lines. Every module goes on the single `-Modules` line
-though, comma-separated. The value takes a mix of plain names and
-version hashtables:
+Each keyword needs its own statement, so a file that needs modules
+carries two lines. A file that needs none carries just the `-Version`
+line. Either way every module goes on the single `-Modules` line,
+comma-separated. The value takes a mix of plain names and version
+hashtables:
 
 ```powershell
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }, Az.Accounts

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -47,6 +47,7 @@
     File:         Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-08-20
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Deploys the Sophos Central CCF (Codeless Connector Framework) package to a Microsoft Sentinel workspace.
@@ -51,8 +53,8 @@
     Created:      2026-08-20
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     Azure CLI (az), logged in with rights to create tables,
-                  DCRs and Sentinel resources
+    Requires:     PowerShell 7.2+, Azure CLI (az), logged in with rights to
+                  create tables, DCRs and Sentinel resources
 
     API versions:
       - Set by the bundled ARM templates rather than by this script, which

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -53,12 +53,18 @@
     Created:      2026-08-20
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Azure CLI (az), logged in with rights to
-                  create tables, DCRs and Sentinel resources
+    Requires:     PowerShell 7.2+, Azure CLI (az) signed in with rights to create tables, DCRs and Sentinel resources
 
     API versions:
-      - Set by the bundled ARM templates rather than by this script, which
-        deploys them through az. Change a version in the template, not here.
+      - Log Analytics tables : 2023-09-01 (custom table create)
+      - Data Collection      : 2023-03-11 (DCR create and read)
+      - Sentinel             : 2024-10-01-preview (connector definition and
+                               poller; CCF has no GA API version yet)
+      - OperationalInsights  : 2025-02-01 (workspace read, for the location
+                               and customer ID the other calls need)
+
+    The bundled ARM templates carry their own versions for the resources they
+    deploy. These five are the ones this script sends on its own az rest calls.
 
 .LINK
     https://learn.microsoft.com/azure/sentinel/create-codeless-connector

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -53,6 +53,13 @@
     Last Updated: 2026-09-01
     Requires:     Azure CLI (az), logged in with rights to create tables,
                   DCRs and Sentinel resources
+
+    API versions:
+      - Set by the bundled ARM templates rather than by this script, which
+        deploys them through az. Change a version in the template, not here.
+
+.LINK
+    https://learn.microsoft.com/azure/sentinel/create-codeless-connector
 #>
 
 [CmdletBinding()]

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
-#
-# Created by noodlemctwoodle on 20/08/2026.
-#
-
 <#
 .SYNOPSIS
     Deploys the Sophos Central CCF (Codeless Connector Framework) package to a Microsoft Sentinel workspace.
@@ -50,6 +44,12 @@
         -ClientId <id> -ClientSecret (Read-Host -AsSecureString "Sophos Client Secret")
 
 .NOTES
+    File:         Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-08-20
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Requires: Azure CLI (az) logged in with rights to create tables, DCRs, and Sentinel resources.
 #>
 

--- a/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
+++ b/Content/CodelessConnectors/Sophos_CCF/Deploy-SophosConnector.ps1
@@ -50,7 +50,8 @@
     Created:      2026-08-20
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires: Azure CLI (az) logged in with rights to create tables, DCRs, and Sentinel resources.
+    Requires:     Azure CLI (az), logged in with rights to create tables,
+                  DCRs and Sentinel resources
 #>
 
 [CmdletBinding()]

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
-#
-# Created by noodlemctwoodle on 18/05/2026.
-#
-
 <#
 .SYNOPSIS
     Exports every dataset behind the Sentinel Data Lake Migration workbook to a
@@ -114,6 +108,12 @@
     absolute or relative path your environment prefers.
 
 .NOTES
+    File:         Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-18
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Authentication : Uses the current Az context (Connect-AzAccount).
     Requires       : PowerShell 7+, Az.Accounts, Az.OperationalInsights, ImportExcel
     Tables API     : 2023-09-01

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights, ImportExcel
 
 <#
@@ -118,7 +118,7 @@
     Created:      2026-05-18
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7+, Az.Accounts, Az.OperationalInsights, ImportExcel
+    Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, ImportExcel
 
     Authentication uses the current Az context, so run Connect-AzAccount
     first.

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -122,8 +122,15 @@
 
     API versions:
       - Log Analytics tables : 2023-09-01
-      - Alert rules          : 2025-09-01
-      - Saved searches       : 2020-08-01
+      - Sentinel alert rules : 2025-09-01
+      - Saved searches       : 2020-08-01 (parser functions, read to work out
+                               which content reaches a table indirectly)
+
+.LINK
+    https://learn.microsoft.com/rest/api/loganalytics/tables
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
 #>
 
 [CmdletBinding()]

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 7.0
+#Requires -Modules Az.Accounts, Az.OperationalInsights, ImportExcel
+
 <#
 .SYNOPSIS
     Exports every dataset behind the Sentinel Data Lake Migration workbook to a

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -114,12 +114,15 @@
     Created:      2026-05-18
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Authentication : Uses the current Az context (Connect-AzAccount).
-    Requires       : PowerShell 7+, Az.Accounts, Az.OperationalInsights, ImportExcel
-    Tables API     : 2023-09-01
-    AlertRules API : 2025-09-01
-    Functions API  : 2020-08-01 (savedSearches)
-    Author         : Toby G
+    Requires:     PowerShell 7+, Az.Accounts, Az.OperationalInsights, ImportExcel
+
+    Authentication uses the current Az context, so run Connect-AzAccount
+    first.
+
+    API versions:
+      - Log Analytics tables : 2023-09-01
+      - Alert rules          : 2025-09-01
+      - Saved searches       : 2020-08-01
 #>
 
 [CmdletBinding()]

--- a/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
+++ b/Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
@@ -111,6 +111,7 @@
     File:         Content/Workbooks/SentinelDataLake/Export-SdlMigrationWorkbook.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-18
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, powershell-yaml
 
 <#
@@ -125,7 +126,7 @@
     Created:        2026-03-20
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Requires:       Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
 
     API versions:
       - Sentinel             : 2025-07-01-preview (preview is required for the
@@ -196,8 +197,6 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
-
-#Requires -Modules Az.Accounts
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -52,6 +52,12 @@
 .PARAMETER SkipDetections
     When specified, skips deploying custom analytics rules.
 
+.PARAMETER SkipCommunityDetections
+    When specified, skips deploying analytics rules imported from the
+    community (those carrying import attribution). Repo-authored rules
+    still deploy. Use it to hold community content back while keeping
+    your own detections flowing.
+
 .PARAMETER SkipWatchlists
     When specified, skips deploying custom watchlists.
 
@@ -72,6 +78,11 @@
 
 .PARAMETER IsGov
     When specified, targets the Azure Government cloud environment.
+
+.PARAMETER SmartDeployment
+    When specified, deploys only content that changed since the last
+    successful run, ordered by the priority list in
+    sentinel-deployment.config. Omit it to deploy the whole content tree.
 
 .PARAMETER WhatIf
     When specified, performs a dry run showing what actions would be taken without
@@ -106,11 +117,11 @@
 
 .NOTES
     File:           Deploy/content/Deploy-CustomContent.ps1
-    Created:        2026-03-20
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-03-20
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     API Version:    2025-07-01-preview
     Requires:       Az.Accounts, powershell-yaml
 #>

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.2
-#Requires -Modules Az.Accounts, powershell-yaml
+#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS
@@ -126,7 +126,7 @@
     Created:        2026-03-20
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml (auto-installed if missing)
 
     API versions:
       - Sentinel             : 2025-07-01-preview (preview is required for the

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, powershell-yaml
+
 <#
 .SYNOPSIS
     Deploys custom Microsoft Sentinel content from the repository to a workspace.

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -119,6 +119,7 @@
     File:           Deploy/content/Deploy-CustomContent.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-03-20
     Version:        1.1.1
     Last Updated:   2026-09-01

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -105,9 +105,11 @@
     Performs a dry run showing what would be deployed.
 
 .NOTES
+    File:           Deploy/content/Deploy-CustomContent.ps1
+    Created:        2026-03-20
     Author:         noodlemctwoodle
-    Version:        1.1.0
-    Last Updated:   2026-04-28
+    Version:        1.1.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     API Version:    2025-07-01-preview
     Requires:       Az.Accounts, powershell-yaml

--- a/Deploy/content/Deploy-CustomContent.ps1
+++ b/Deploy/content/Deploy-CustomContent.ps1
@@ -123,8 +123,19 @@
     Created:        2026-03-20
     Version:        1.1.1
     Last Updated:   2026-09-01
-    API Version:    2025-07-01-preview
     Requires:       Az.Accounts, powershell-yaml
+
+    API versions:
+      - Sentinel             : 2025-07-01-preview (preview is required for the
+                               newer rule properties this deployer sets)
+      - Log Analytics tables : 2022-10-01 (read to decide whether a rule can
+                               deploy enabled or must deploy disabled)
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/watchlists
 #>
 
 [CmdletBinding()]

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.2
-#Requires -Modules Az.Accounts, powershell-yaml
+#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS
@@ -54,7 +54,7 @@
     Version:        1.0.2
     Last Updated:   2026-09-01
     Permissions:    CustomDetection.ReadWrite.All (Application)
-    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml (auto-installed if missing)
 
     API versions:
       - Microsoft Graph Security : beta (custom detection rules are not yet

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, powershell-yaml
 
 <#
@@ -53,7 +54,7 @@
     Version:        1.0.2
     Last Updated:   2026-09-01
     Permissions:    CustomDetection.ReadWrite.All (Application)
-    Requires:       Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
 
     API versions:
       - Microsoft Graph Security : beta (custom detection rules are not yet
@@ -74,8 +75,6 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
-
-#Requires -Modules Az.Accounts
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -43,9 +43,11 @@
     Performs a dry run showing what rules would be deployed.
 
 .NOTES
+    File:           Deploy/content/Deploy-DefenderDetections.ps1
+    Created:        2026-03-20
     Author:         noodlemctwoodle
-    Version:        1.0.1
-    Last Updated:   2026-04-28
+    Version:        1.0.2
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     API Version:    Microsoft Graph Security API (beta)
     Requires:       Az.Accounts, powershell-yaml

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, powershell-yaml
+
 <#
 .SYNOPSIS
     Deploys custom detection rules to Microsoft Defender XDR via the Graph Security API.

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -46,12 +46,13 @@
     File:           Deploy/content/Deploy-DefenderDetections.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-03-20
     Version:        1.0.2
     Last Updated:   2026-09-01
     API Version:    Microsoft Graph Security API (beta)
-    Requires:       Az.Accounts, powershell-yaml
     Permissions:    CustomDetection.ReadWrite.All (Application)
+    Requires:       Az.Accounts, powershell-yaml
 #>
 
 [CmdletBinding()]

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -50,9 +50,15 @@
     Created:        2026-03-20
     Version:        1.0.2
     Last Updated:   2026-09-01
-    API Version:    Microsoft Graph Security API (beta)
     Permissions:    CustomDetection.ReadWrite.All (Application)
     Requires:       Az.Accounts, powershell-yaml
+
+    API versions:
+      - Microsoft Graph Security : beta (custom detection rules are not yet
+                                   on the v1.0 endpoint)
+
+.LINK
+    https://learn.microsoft.com/graph/api/resources/security-customdetectionrule
 #>
 
 [CmdletBinding()]

--- a/Deploy/content/Deploy-DefenderDetections.ps1
+++ b/Deploy/content/Deploy-DefenderDetections.ps1
@@ -44,11 +44,11 @@
 
 .NOTES
     File:           Deploy/content/Deploy-DefenderDetections.ps1
-    Created:        2026-03-20
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-03-20
     Version:        1.0.2
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     API Version:    Microsoft Graph Security API (beta)
     Requires:       Az.Accounts, powershell-yaml
     Permissions:    CustomDetection.ReadWrite.All (Application)

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -115,8 +115,18 @@
     Created:        2026-03-20
     Version:        2.1.1
     Last Updated:   2026-09-01
-    API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts
+
+    API versions:
+      - Sentinel  : 2025-09-01 (GA)
+      - Workbooks : 2022-04-01 (Microsoft.Insights/workbooks, used when a
+                    solution ships a workbook alongside its rules)
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
+
+.LINK
+    https://learn.microsoft.com/rest/api/application-insights/workbooks
 #>
 
 [CmdletBinding()]

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts
+
 <#
 .SYNOPSIS
     Deploys Microsoft Sentinel Content Hub solutions and their associated content to a workspace.

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -108,9 +108,11 @@
     Performs a dry run showing what would be deployed without making any changes.
 
 .NOTES
+    File:           Deploy/content/Deploy-SentinelContentHub.ps1
+    Created:        2026-03-20
     Author:         noodlemctwoodle
-    Version:        2.1.0
-    Last Updated:   2026-04-28
+    Version:        2.1.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts
 
 <#
@@ -117,7 +118,7 @@
     Created:        2026-03-20
     Version:        2.1.1
     Last Updated:   2026-09-01
-    Requires:       Az.Accounts
+    Requires:       PowerShell 7.2+, Az.Accounts
 
     API versions:
       - Sentinel  : 2025-09-01 (GA)
@@ -185,8 +186,6 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
-
-#Requires -Modules Az.Accounts
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -111,6 +111,7 @@
     File:           Deploy/content/Deploy-SentinelContentHub.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-03-20
     Version:        2.1.1
     Last Updated:   2026-09-01

--- a/Deploy/content/Deploy-SentinelContentHub.ps1
+++ b/Deploy/content/Deploy-SentinelContentHub.ps1
@@ -109,11 +109,11 @@
 
 .NOTES
     File:           Deploy/content/Deploy-SentinelContentHub.ps1
-    Created:        2026-03-20
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-03-20
     Version:        2.1.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts
 #>

--- a/Deploy/permissions/Set-PlaybookPermissions.ps1
+++ b/Deploy/permissions/Set-PlaybookPermissions.ps1
@@ -44,16 +44,17 @@
     File:           Deploy/permissions/Set-PlaybookPermissions.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-04-28
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       Az.Accounts, Az.Resources, Az.LogicApp
     Permissions:    User Access Administrator OR Owner on the playbook resource
                     group (and Sentinel resource group, if different).
                     The deployment SPN's ABAC-conditioned UAA does NOT
                     permit Sentinel-tier role assignments, so this script
                     is intended for ad-hoc execution by a separate elevated
                     identity rather than the pipeline SPN.
+    Requires:       Az.Accounts, Az.Resources, Az.LogicApp
 #>
 
 [CmdletBinding()]

--- a/Deploy/permissions/Set-PlaybookPermissions.ps1
+++ b/Deploy/permissions/Set-PlaybookPermissions.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.Resources, Az.LogicApp
 
 <#
@@ -56,7 +57,7 @@
                     permit Sentinel-tier role assignments, so this script
                     is intended for ad-hoc execution by a separate elevated
                     identity rather than the pipeline SPN.
-    Requires:       Az.Accounts, Az.Resources, Az.LogicApp
+    Requires:       PowerShell 7.2+, Az.Accounts, Az.Resources, Az.LogicApp
 #>
 
 [CmdletBinding()]

--- a/Deploy/permissions/Set-PlaybookPermissions.ps1
+++ b/Deploy/permissions/Set-PlaybookPermissions.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, Az.Resources, Az.LogicApp
+
 <#
 .SYNOPSIS
     Assigns required RBAC roles to Logic App managed identities after playbook deployment.

--- a/Deploy/permissions/Set-PlaybookPermissions.ps1
+++ b/Deploy/permissions/Set-PlaybookPermissions.ps1
@@ -41,9 +41,11 @@
         -KeyVaultName "kv-sentinel-prod"
 
 .NOTES
+    File:           Deploy/permissions/Set-PlaybookPermissions.ps1
+    Created:        2026-04-28
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-28
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       Az.Accounts, Az.Resources, Az.LogicApp
     Permissions:    User Access Administrator OR Owner on the playbook resource

--- a/Deploy/permissions/Set-PlaybookPermissions.ps1
+++ b/Deploy/permissions/Set-PlaybookPermissions.ps1
@@ -42,11 +42,11 @@
 
 .NOTES
     File:           Deploy/permissions/Set-PlaybookPermissions.ps1
-    Created:        2026-04-28
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-04-28
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       Az.Accounts, Az.Resources, Az.LogicApp
     Permissions:    User Access Administrator OR Owner on the playbook resource
                     group (and Sentinel resource group, if different).

--- a/Deploy/permissions/Set-RunbookPermissions.ps1
+++ b/Deploy/permissions/Set-RunbookPermissions.ps1
@@ -28,9 +28,11 @@
     Switch to remove the role assignments instead of creating them.
 
 .NOTES
+    File:           Deploy/permissions/Set-RunbookPermissions.ps1
+    Created:        2026-03-23
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-03-23
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Website:        https://sentinel.blog
     Requires:       Azure CLI (az), Owner or User Access Administrator on subscription

--- a/Deploy/permissions/Set-RunbookPermissions.ps1
+++ b/Deploy/permissions/Set-RunbookPermissions.ps1
@@ -27,23 +27,30 @@
 .PARAMETER Remove
     Switch to remove the role assignments instead of creating them.
 
+.PARAMETER SentinelResourceGroup
+    Resource group containing the Sentinel workspace. Scopes the
+    watchlist-write role assignment to that resource group rather than the
+    whole subscription.
+
+.EXAMPLE
+    ./Deploy/permissions/Set-RunbookPermissions.ps1 -SubscriptionId '00000000-0000-0000-0000-000000000000'
+
+    Applies the runbook role assignments to the subscription.
+
+.EXAMPLE
+    ./Deploy/permissions/Set-RunbookPermissions.ps1 -SubscriptionId '00000000-0000-0000-0000-000000000000' -Remove
+
+    Removes the role assignments this script previously applied.
+
 .NOTES
     File:           Deploy/permissions/Set-RunbookPermissions.ps1
-    Created:        2026-03-23
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-03-23
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Website:        https://sentinel.blog
     Requires:       Azure CLI (az), Owner or User Access Administrator on subscription
-
-.EXAMPLE
-    # Apply permissions
-    .\Set-RunbookPermissions.ps1 -SubscriptionId '00000000-0000-0000-0000-000000000000'
-
-.EXAMPLE
-    # Remove permissions
-    .\Set-RunbookPermissions.ps1 -SubscriptionId '00000000-0000-0000-0000-000000000000' -Remove
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/Deploy/permissions/Set-RunbookPermissions.ps1
+++ b/Deploy/permissions/Set-RunbookPermissions.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Assigns RBAC permissions to the DCR Watchlist Sync Automation Account
@@ -50,7 +52,7 @@
     Created:        2026-03-23
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       Azure CLI (az), Owner or User Access Administrator on subscription
+    Requires:       PowerShell 7.2+, Azure CLI (az), Owner or User Access Administrator on subscription
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/Deploy/permissions/Set-RunbookPermissions.ps1
+++ b/Deploy/permissions/Set-RunbookPermissions.ps1
@@ -46,10 +46,10 @@
     File:           Deploy/permissions/Set-RunbookPermissions.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-03-23
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Website:        https://sentinel.blog
     Requires:       Azure CLI (az), Owner or User Access Administrator on subscription
 #>
 

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, Az.Resources
+
 <#
 .SYNOPSIS
     One-time bootstrap: grants the deployment SPN all permissions needed

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.Resources
 
 <#
@@ -71,7 +72,7 @@
                     subscription AND at least Privileged Role Administrator
                     in Entra ID. Run ONCE; the pipeline SPN is fully
                     autonomous after.
-    Requires:       Az.Accounts, Az.Resources, Microsoft.Graph
+    Requires:       PowerShell 7.2+, Az.Accounts, Az.Resources, Microsoft.Graph (auto-installed if missing)
 #>
 
 [CmdletBinding()]

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -61,14 +61,15 @@
     File:           Deploy/setup/Setup-ServicePrincipal.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-03-21
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       Az.Accounts, Az.Resources, Microsoft.Graph
     Permissions:    The user running this script needs Owner on the target
                     subscription AND at least Privileged Role Administrator
                     in Entra ID. Run ONCE; the pipeline SPN is fully
                     autonomous after.
+    Requires:       Az.Accounts, Az.Resources, Microsoft.Graph
 #>
 
 [CmdletBinding()]

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -58,9 +58,11 @@
         -SkipGraphPermission
 
 .NOTES
+    File:           Deploy/setup/Setup-ServicePrincipal.ps1
+    Created:        2026-03-21
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-28
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       Az.Accounts, Az.Resources, Microsoft.Graph
     Permissions:    The user running this script needs Owner on the target

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -59,11 +59,11 @@
 
 .NOTES
     File:           Deploy/setup/Setup-ServicePrincipal.ps1
-    Created:        2026-03-21
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-03-21
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       Az.Accounts, Az.Resources, Microsoft.Graph
     Permissions:    The user running this script needs Owner on the target
                     subscription AND at least Privileged Role Administrator

--- a/Deploy/setup/Setup-ServicePrincipal.ps1
+++ b/Deploy/setup/Setup-ServicePrincipal.ps1
@@ -72,7 +72,10 @@
                     subscription AND at least Privileged Role Administrator
                     in Entra ID. Run ONCE; the pipeline SPN is fully
                     autonomous after.
-    Requires:       PowerShell 7.2+, Az.Accounts, Az.Resources, Microsoft.Graph (auto-installed if missing)
+    Requires:       PowerShell 7.2+, Az.Accounts, Az.Resources,
+                    Microsoft.Graph.Identity.Governance,
+                    Microsoft.Graph.Applications (both auto-installed if
+                    missing, each pulling in Microsoft.Graph.Authentication)
 #>
 
 [CmdletBinding()]
@@ -310,10 +313,10 @@ if ($SkipEntraRole) {
     $secAdminTemplateId = "194ae4cb-b126-40b2-bd5b-6091b380977d"
 
     try {
-        # Check if Microsoft.Graph module is available
-        if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Identity.DirectoryManagement)) {
-            Write-Host "  Installing Microsoft.Graph.Identity.DirectoryManagement module..." -ForegroundColor Yellow
-            Install-Module -Name Microsoft.Graph.Identity.DirectoryManagement -Force -Scope CurrentUser -AllowClobber
+        # Role-management cmdlets ship in Identity.Governance, not Identity.DirectoryManagement
+        if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Identity.Governance)) {
+            Write-Host "  Installing Microsoft.Graph.Identity.Governance module..." -ForegroundColor Yellow
+            Install-Module -Name Microsoft.Graph.Identity.Governance -Force -Scope CurrentUser -AllowClobber
         }
 
         # Connect to Graph if not already connected
@@ -359,7 +362,7 @@ if ($SkipGraphPermission) {
     $results += @{ Step = "CustomDetection.ReadWrite.All (Graph)"; Status = "Skipped" }
 } else {
     try {
-        # Check if Microsoft.Graph module is available
+        # App-role assignment cmdlets ship in Microsoft.Graph.Applications
         if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Applications)) {
             Write-Host "  Installing Microsoft.Graph.Applications module..." -ForegroundColor Yellow
             Install-Module -Name Microsoft.Graph.Applications -Force -Scope CurrentUser -AllowClobber

--- a/Docs/Deploy/PowerShell-Module-Requirements.md
+++ b/Docs/Deploy/PowerShell-Module-Requirements.md
@@ -43,7 +43,7 @@ needed to validate the project.
 | `Az.ManagedServiceIdentity` | Service-principal / managed-identity setup (per [Scripts](Scripts.md)) | docs |
 | `Az.OperationalInsights` | [`Sentinel-Deploy.yml`](../../Pipelines/Sentinel-Deploy.yml) and the nightly workflow (`Get-AzOperationalInsightsWorkspace`); Documenter collector | cmdlet usage |
 | `Microsoft.Graph.Applications` | [`Setup-ServicePrincipal.ps1`](../../Deploy/setup/Setup-ServicePrincipal.ps1) | `Install-Module` (auto) |
-| `Microsoft.Graph.Identity.DirectoryManagement` | [`Setup-ServicePrincipal.ps1`](../../Deploy/setup/Setup-ServicePrincipal.ps1) | `Install-Module` (auto) |
+| `Microsoft.Graph.Identity.Governance` | [`Setup-ServicePrincipal.ps1`](../../Deploy/setup/Setup-ServicePrincipal.ps1) - supplies the `*-MgRoleManagementDirectoryRoleAssignment` cmdlets | `Install-Module` (auto) |
 | `powershell-yaml` | [`Deploy-CustomContent.ps1`](../../Deploy/content/Deploy-CustomContent.ps1), [`Deploy-DefenderDetections.ps1`](../../Deploy/content/Deploy-DefenderDetections.ps1), [`Import-CommunityRules.ps1`](../../Tools/Import-CommunityRules.ps1), [`Build-DependencyManifest.ps1`](../../Tools/Build-DependencyManifest.ps1), [`Test-SentinelRuleDrift.ps1`](../../Tools/Test-SentinelRuleDrift.ps1) | `Install-Module` (auto) |
 | `Sentinel.Common` (local) | Every deploy script plus [`Build-DependencyManifest.ps1`](../../Tools/Build-DependencyManifest.ps1) | `Import-Module` from `Modules/` |
 
@@ -100,7 +100,7 @@ Install-Module Az.Resources, Az.KeyVault, Az.ManagedServiceIdentity, `
     Az.LogicApp, Az.OperationalInsights, Az.SecurityInsights, Az.Monitor `
     -Scope CurrentUser -Force
 Install-Module Microsoft.Graph.Applications, `
-    Microsoft.Graph.Identity.DirectoryManagement -Scope CurrentUser -Force
+    Microsoft.Graph.Identity.Governance -Scope CurrentUser -Force
 
 # Only for the standalone SDL workbook export
 Install-Module ImportExcel -Scope CurrentUser -Force

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -68,7 +68,7 @@ declaration order), `.OUTPUTS`, `.EXAMPLE`, `.NOTES`, `.LINK`.
     Created:      2026-03-20
     Version:      2.1.1
     Last Updated: 2026-09-01
-    Requires:     Az.Accounts
+    Requires:     PowerShell 7.2+, Az.Accounts
 
     API versions:
       - Sentinel  : 2025-09-01 (GA)

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -126,7 +126,9 @@ One-time bootstrap script that grants the service principal all required Azure, 
 - Service Principal (app registration) already created
 - The user running the script needs Owner on the target subscription and at least Privileged Role Administrator in Entra ID to grant these permissions
 - Authenticated Azure context (`Connect-AzAccount`)
-- `Az.Accounts`, `Az.Resources`, and `Microsoft.Graph` PowerShell modules
+- `Az.Accounts` and `Az.Resources` PowerShell modules, plus
+  `Microsoft.Graph.Identity.Governance` and `Microsoft.Graph.Applications`
+  (the script installs the two Graph submodules itself if they are missing)
 
 ### Parameter Reference
 

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -28,10 +28,30 @@ one-time bootstrap and ad-hoc maintenance tooling.
 
 ## Script header convention
 
-Every `.ps1` and `.psm1` in the repo opens with a comment-based help
-block and nothing above it except `#Requires` statements. There is no
-separate `#`-comment banner; the path, author and dates live in
-`.NOTES`.
+Every `.ps1` and `.psm1` in the repo opens with its `#Requires`
+statements, then a comment-based help block, and nothing else above
+either. There is no separate `#`-comment banner; the path, author and
+dates live in `.NOTES`.
+
+```powershell
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources
+
+<#
+.SYNOPSIS
+    ...
+```
+
+`Requires:` in `.NOTES` and the `#Requires` statements must stay in
+step in both directions. `#Requires` is the functional gate, enforced
+when the file is run, dot-sourced or imported; `Requires:` is the
+human-readable summary. Neither may name something the other omits.
+
+Two things never go in `#Requires -Modules`, because it resolves
+against `PSModulePath` and fails the load when it cannot:
+`Sentinel.Common`, which is imported by path, and CLI tooling such as
+the Azure CLI or pandoc, which are not modules. Both still belong in
+`Requires:`.
 
 Keywords appear in a fixed order, with a blank line between each:
 `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER` (one per parameter, in

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -47,11 +47,13 @@ step in both directions. `#Requires` is the functional gate, enforced
 when the file is run, dot-sourced or imported; `Requires:` is the
 human-readable summary. Neither may name something the other omits.
 
-Two things never go in `#Requires -Modules`, because it resolves
+Three things never go in `#Requires -Modules`, because it resolves
 against `PSModulePath` and fails the load when it cannot:
-`Sentinel.Common`, which is imported by path, and CLI tooling such as
-the Azure CLI or pandoc, which are not modules. Both still belong in
-`Requires:`.
+`Sentinel.Common`, which is imported by path; CLI tooling such as the
+Azure CLI or pandoc, which are not modules; and anything the file
+installs itself, since `#Requires` aborts before the install can run.
+All three still belong in `Requires:`, the self-installing ones marked
+`(auto-installed if missing)`.
 
 Keywords appear in a fixed order, with a blank line between each:
 `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER` (one per parameter, in

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -42,6 +42,12 @@ dates live in `.NOTES`.
     ...
 ```
 
+Each `#Requires` keyword needs its own statement, so the prologue is
+always at least two lines, but every module shares the one `-Modules`
+line. It accepts a mix of plain names and version hashtables, so
+`@{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }, Az.Accounts` is
+one statement rather than two.
+
 `Requires:` in `.NOTES` and the `#Requires` statements must stay in
 step in both directions. `#Requires` is the functional gate, enforced
 when the file is run, dot-sourced or imported; `Requires:` is the

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -26,6 +26,59 @@ one-time bootstrap and ad-hoc maintenance tooling.
 | `Test-PullRequestTemplate.ps1` | Validates a PR description against `.github/PULL_REQUEST_TEMPLATE.md`; drives the PR Template Validation workflow | See [Pipelines](../Pipelines/README.md) |
 | `Test-SentinelRuleDrift.ps1` | Detects portal-edited rules and absorbs Custom drift | See [Sentinel Drift Detection](../Tools/Sentinel-Drift-Detection.md) |
 
+## Script header convention
+
+Every `.ps1` and `.psm1` in the repo opens with a comment-based help
+block and nothing above it except `#Requires` statements. There is no
+separate `#`-comment banner; the path, author and dates live in
+`.NOTES`.
+
+Keywords appear in a fixed order, with a blank line between each:
+`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER` (one per parameter, in
+declaration order), `.OUTPUTS`, `.EXAMPLE`, `.NOTES`, `.LINK`.
+
+`.NOTES` carries the same eight keys everywhere, aligned to one column:
+
+```powershell
+.NOTES
+    File:         Deploy/content/Deploy-SentinelContentHub.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
+    Created:      2026-03-20
+    Version:      2.1.1
+    Last Updated: 2026-09-01
+    Requires:     Az.Accounts
+
+    API versions:
+      - Sentinel  : 2025-09-01 (GA)
+      - Workbooks : 2022-04-01 (Microsoft.Insights/workbooks, used when a
+                    solution ships a workbook alongside its rules)
+```
+
+Optional extras (`Component:`, `Permissions:`) sit between
+`Last Updated:` and `Requires:`, so `Requires:` is always the last key.
+Free-form prose goes after a blank line, never welded onto the end of
+the keys.
+
+Two rules worth calling out, because they are easy to get wrong:
+
+- **Anything that calls an Azure or Graph API records every version it
+  pins**, in an `API versions:` block after the keys, one line per API
+  with colons aligned. Use the parenthetical to say why a version was
+  chosen where that is not obvious; it is the part a reader cannot
+  recover from the code. `#Requires` statements are the functional
+  gate for modules; `Requires:` is the human-readable summary and must
+  name everything they enforce.
+- **Files implementing a documented API contract carry a `.LINK` to
+  the Microsoft Learn REST reference** for that API, one URL per
+  entry. Link the reference, not a conceptual overview, and check the
+  URL resolves before committing it.
+
+Full rules, including the variants for function-library files and
+Pester suites, are in
+[`.github/instructions/powershell-scripts.instructions.md`](../../.github/instructions/powershell-scripts.instructions.md).
+
 ## Setup-ServicePrincipal.ps1
 
 One-time bootstrap script that grants the service principal all required Azure, Entra ID, and Microsoft Graph permissions needed for the pipeline to operate autonomously.

--- a/Docs/Deploy/Scripts.md
+++ b/Docs/Deploy/Scripts.md
@@ -42,8 +42,9 @@ dates live in `.NOTES`.
     ...
 ```
 
-Each `#Requires` keyword needs its own statement, so the prologue is
-always at least two lines, but every module shares the one `-Modules`
+Each `#Requires` keyword needs its own statement, so a file that needs
+modules carries two lines and a file that needs none carries just the
+`-Version` line. Either way every module shares the one `-Modules`
 line. It accepts a mix of plain names and version hashtables, so
 `@{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }, Az.Accounts` is
 one statement rather than two.

--- a/Docs/Guides/Sentinel-As-Code-Build-and-Test-Guide.md
+++ b/Docs/Guides/Sentinel-As-Code-Build-and-Test-Guide.md
@@ -196,7 +196,7 @@ looser.
 | [Az.ManagedServiceIdentity](https://learn.microsoft.com/powershell/module/az.managedserviceidentity/) | Service-principal / managed-identity setup | docs |
 | [Az.OperationalInsights](https://learn.microsoft.com/powershell/module/az.operationalinsights/) | Deploy pipeline and nightly workflow; Documenter collector | cmdlet usage |
 | [Microsoft.Graph.Applications](https://learn.microsoft.com/powershell/module/microsoft.graph.applications/) | `Setup-ServicePrincipal` | `Install-Module` (auto) |
-| [Microsoft.Graph.Identity.DirectoryManagement](https://learn.microsoft.com/powershell/module/microsoft.graph.identity.directorymanagement/) | `Setup-ServicePrincipal` | `Install-Module` (auto) |
+| [Microsoft.Graph.Identity.Governance](https://learn.microsoft.com/powershell/module/microsoft.graph.identity.governance/) | `Setup-ServicePrincipal` | `Install-Module` (auto) |
 | [powershell-yaml](https://www.powershellgallery.com/packages/powershell-yaml) | `Deploy-CustomContent`; `Deploy-DefenderDetections`; `Export-DefenderDetections`; `Import-CommunityRules`; `Build-DependencyManifest` | `Install-Module` (auto) |
 | `Sentinel.Common` (local) | Every deploy script plus `Build-DependencyManifest` | `Import-Module` from `Modules/` |
 
@@ -603,7 +603,7 @@ Install-Module Az.Resources, Az.KeyVault, Az.ManagedServiceIdentity, `
   -Scope CurrentUser -Force
 
 Install-Module Microsoft.Graph.Applications, `
-  Microsoft.Graph.Identity.DirectoryManagement -Scope CurrentUser -Force
+  Microsoft.Graph.Identity.Governance -Scope CurrentUser -Force
 ```
 
 ### 10.3 Only for the standalone SDL workbook export

--- a/Docs/Releases/CHANGELOG.md
+++ b/Docs/Releases/CHANGELOG.md
@@ -4,6 +4,52 @@ Customer-facing changes to Sentinel-As-Code, newest first. Releases use CalVer
 (`YY.0M`) — see [Versioning](Versioning.md). "Wave N" was the previous release
 label (now retired); the wave → CalVer mapping is in [Versioning](Versioning.md).
 
+## 26.09
+
+Connector, workbook and content-hygiene release, plus a repository-wide
+standardisation of PowerShell file headers.
+
+- **Sophos Central codeless connector** — a Codeless Connector Framework (CCF)
+  package that ingests Sophos Central SIEM API events and alerts with no Logic
+  App or Function App in the path. Auth is OAuth2 client credentials, paging is
+  cursor-based over `NextPageToken`, and raw snake_case field names are
+  translated to PascalCase in the DCR transform so the translation lives in
+  exactly one place. Deploy-time placeholders keep the package portable across
+  workspaces and regions. This is the first CCF package in the repository and
+  establishes `Content/CodelessConnectors/` as the home for the pattern.
+- **Detection Engineering dashboard** — a nine-tab workbook covering the health,
+  coverage, fidelity and lifecycle of the detection portfolio: rule inventory
+  and health, MITRE coverage, alert fidelity, incident outcomes, ingestion, and
+  engineering velocity. Built on the `AlertInfo` advanced-hunting table rather
+  than `SecurityAlert`, so it spans Defender for Endpoint, Office 365, Identity
+  and Cloud Apps alongside custom detections, and still returns data in unified
+  SecOps tenants where `SentinelHealth` and `SentinelAudit` are not enabled. It
+  also surfaces which classic custom tables are still posting to the Azure
+  Monitor HTTP Data Collector API, which loses support on 14 September 2026.
+  Ships with a reference page and an Overview screenshot.
+- **Connector metadata corrections** — `requiredDataConnectors` fixed on 14
+  analytical rules that carried authoring placeholders (`YourConnectorId`),
+  empty connector blocks, non-existent connector IDs, or data types the named
+  connector does not emit. Nothing failed at deploy time, which is why the
+  errors survived, but the metadata feeds Content Hub solution mapping and the
+  dependency-impact scoring in `Invoke-TableMigrationReview.ps1`, so wrong
+  values there produced wrong answers in migration assessments. No detection
+  logic changed.
+- **PowerShell file headers standardised** — every `.ps1` and `.psm1` in the
+  repository now opens with its `#Requires` statements, then a comment-based
+  help block, and nothing else above either. The five-line `#` path/date banner
+  is gone and its metadata moved into `.NOTES`, which now carries the same eight
+  keys everywhere. Scripts also declare their real dependencies as `#Requires`
+  statements rather than only in prose, so a missing module now fails at the
+  door instead of part-way through a deployment. Modules a script installs for
+  itself stay out of `#Requires`, since the statement aborts the load before the
+  install could run. The change is comment-only, verified by comparing the
+  executable token stream of all 64 files before and after.
+- **Notebook ordering** — the data-lake demo notebooks are zero-padded
+  (`demo01` to `demo18`) so GitHub's lexical file listing matches the order the
+  catalogue presents them in, rather than burying the connect-and-orient
+  notebook two thirds of the way down.
+
 ## 26.07.3
 
 Data-lake tooling release: two migration toolkits for moving off classic custom

--- a/Docs/Releases/CHANGELOG.md
+++ b/Docs/Releases/CHANGELOG.md
@@ -43,8 +43,19 @@ standardisation of PowerShell file headers.
   statements rather than only in prose, so a missing module now fails at the
   door instead of part-way through a deployment. Modules a script installs for
   itself stay out of `#Requires`, since the statement aborts the load before the
-  install could run. The change is comment-only, verified by comparing the
-  executable token stream of all 64 files before and after.
+  install could run. The header rewrite itself is comment-only, verified by
+  comparing the executable token stream of all 64 files before and after; the
+  one behavioural change that came out of this work is listed separately below.
+- **Setup-ServicePrincipal installs the right Graph submodule** — the Entra ID
+  role-assignment step installed `Microsoft.Graph.Identity.DirectoryManagement`
+  but called `Get-MgRoleManagementDirectoryRoleAssignment` and its `New-`
+  counterpart, both of which ship in `Microsoft.Graph.Identity.Governance`. On a
+  machine that already had Governance present the step worked by accident; on a
+  clean machine the install succeeded, the cmdlet lookup failed, and the catch
+  block reported it as a missing Privileged Role Administrator permission,
+  sending anyone debugging it after a problem that did not exist. The script now
+  installs `Microsoft.Graph.Identity.Governance`, and the docs that repeated the
+  wrong module name were corrected with it.
 - **Notebook ordering** — the data-lake demo notebooks are zero-padded
   (`demo01` to `demo18`) so GitHub's lexical file listing matches the order the
   catalogue presents them in, rather than burying the connect-and-orient

--- a/Docs/Releases/Versioning.md
+++ b/Docs/Releases/Versioning.md
@@ -69,6 +69,7 @@ immutable git history). The mapping:
 | Copilot activity monitoring content pack, Sentinel as Code Toolkit, PR template validation gate | `26.07.1` | PR #30, PR #31 |
 | Documentation overhaul, Toolkit and pipeline docs, Docs restructure, deploy fixes | `26.07.2` | PR #33 |
 | Classic-to-DCR and DCR-from-schema toolkits, Spark notebooks, MCP prompt books, drift-sync fix, docs housekeeping | `26.07.3` | PR #34, PR #35, PR #37, PR #40, PR #42, PR #43, PR #44, PR #45, PR #46, PR #47 |
+| Sophos codeless connector, Detection Engineering dashboard, connector-metadata corrections, PowerShell header standardisation | `26.09` | PR #49, PR #50, PR #52, PR #53, PR #54, PR #55, PR #57 |
 
 None of these releases were git-tagged; each shipped as a `release/<CalVer>`
 branch merged to `main` and, where published, a GitHub Release. The

--- a/Docs/Tests/Pester-Tests.md
+++ b/Docs/Tests/Pester-Tests.md
@@ -214,6 +214,7 @@ Each test file follows this skeleton (see
 for the full real example):
 
 ```powershell
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Docs/Tests/Pester-Tests.md
+++ b/Docs/Tests/Pester-Tests.md
@@ -216,7 +216,34 @@ for the full real example):
 ```powershell
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
-<# .SYNOPSIS / .DESCRIPTION / .NOTES #>
+<#
+.SYNOPSIS
+    One sentence: what this suite covers.
+
+.DESCRIPTION
+    Which functions are pinned, and what is deliberately not covered
+    (anything needing a live workspace usually is not).
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-<ScriptName>.Tests.ps1
+
+    Runs the whole suite.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-<ScriptName>.Tests.ps1 -FullName '*FunctionName*'
+
+    Runs one Describe block.
+
+.NOTES
+    File:         Tests/Test-<ScriptName>.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
+    Created:      YYYY-MM-DD
+    Version:      0.1.0
+    Last Updated: YYYY-MM-DD
+    Requires:     PowerShell 7.2+, Pester 5+
+#>
 
 BeforeAll {
     # 1. Resolve the source script path. Scripts do NOT live directly under

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -37,10 +37,18 @@
     Last Updated:   2026-09-01
     Requires:       PowerShell 7.2+, Az.Accounts
 
+    API versions:
+      - Log Analytics workspaces : 2022-10-01 (the only version this module
+                                   pins; every other call takes its version
+                                   from the caller)
+
     This file defines functions rather than running. Per-parameter and
     per-example detail lives on each exported function's own help block.
     The module's shipped version is ModuleVersion in Sentinel.Common.psd1,
     which is what Import-Module reads.
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
 #>
 
 Set-StrictMode -Version Latest

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -36,7 +36,7 @@
     Author:         noodlemctwoodle
     Website:        https://sentinel.blog
     Created:        2026-05-13
-    Version:        1.0.1
+    Version:        1.1.1
     Last Updated:   2026-09-01
     Requires:       PowerShell 7.2+, Az.Accounts
 

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -31,6 +31,7 @@
     File:           Modules/Sentinel.Common/Sentinel.Common.psm1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -28,9 +28,11 @@
       caller's).
 
 .NOTES
+    File:           Modules/Sentinel.Common/Sentinel.Common.psm1
+    Created:        2026-05-13
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-29
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Az.Accounts
 #>

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -1,3 +1,6 @@
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts
+
 <#
 .SYNOPSIS
     Shared helpers used across the Sentinel-As-Code deployer scripts and the

--- a/Modules/Sentinel.Common/Sentinel.Common.psm1
+++ b/Modules/Sentinel.Common/Sentinel.Common.psm1
@@ -29,12 +29,17 @@
 
 .NOTES
     File:           Modules/Sentinel.Common/Sentinel.Common.psm1
-    Created:        2026-05-13
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Az.Accounts
+
+    This file defines functions rather than running. Per-parameter and
+    per-example detail lives on each exported function's own help block.
+    The module's shipped version is ModuleVersion in Sentinel.Common.psd1,
+    which is what Import-Module reads.
 #>
 
 Set-StrictMode -Version Latest

--- a/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+++ b/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+++ b/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
@@ -12,6 +12,14 @@
 
     Output is written to a temp folder so repeated test runs don't pollute the
     fixture or the working tree.
+
+.NOTES
+    File:         Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-06-03
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+++ b/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
@@ -28,6 +28,7 @@
     File:         Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+++ b/Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
@@ -13,6 +13,17 @@
     Output is written to a temp folder so repeated test runs don't pollute the
     fixture or the working tree.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
+
+    Runs the full renderer suite against the sample fixture.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for working out which section file
+    failed to render.
+
 .NOTES
     File:         Tests/Documenter/Convert-SentinelInventoryToMarkdown.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -20,6 +31,7 @@
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Documenter/Get-SentinelGap.Tests.ps1
+++ b/Tests/Documenter/Get-SentinelGap.Tests.ps1
@@ -45,6 +45,7 @@
     File:         Tests/Documenter/Get-SentinelGap.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Documenter/Get-SentinelGap.Tests.ps1
+++ b/Tests/Documenter/Get-SentinelGap.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Documenter/Get-SentinelGap.Tests.ps1
+++ b/Tests/Documenter/Get-SentinelGap.Tests.ps1
@@ -28,6 +28,14 @@
 
     Adding new rules requires extending the fixture and adding a row in the
     expected-IDs list.
+
+.NOTES
+    File:         Tests/Documenter/Get-SentinelGap.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-06-03
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeDiscovery {

--- a/Tests/Documenter/Get-SentinelGap.Tests.ps1
+++ b/Tests/Documenter/Get-SentinelGap.Tests.ps1
@@ -29,6 +29,18 @@
     Adding new rules requires extending the fixture and adding a row in the
     expected-IDs list.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Get-SentinelGap.Tests.ps1
+
+    Runs the full gap-analysis suite against the deliberately-broken
+    fixture.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Get-SentinelGap.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which SENT-* rule
+    stopped firing.
+
 .NOTES
     File:         Tests/Documenter/Get-SentinelGap.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -36,6 +48,7 @@
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+++ b/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+++ b/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
@@ -16,6 +16,14 @@
 
     To exercise the build logic without going to Azure we mock
     Invoke-AzRestMethod and capture the URL the helper would have sent.
+
+.NOTES
+    File:         Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-06-03
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+++ b/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
@@ -33,6 +33,7 @@
     File:         Tests/Documenter/Invoke-SentinelRest.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+++ b/Tests/Documenter/Invoke-SentinelRest.Tests.ps1
@@ -17,6 +17,18 @@
     To exercise the build logic without going to Azure we mock
     Invoke-AzRestMethod and capture the URL the helper would have sent.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Invoke-SentinelRest.Tests.ps1
+
+    Runs the URL-construction suite. Needs no Azure auth; the REST call
+    is mocked.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Documenter/Invoke-SentinelRest.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, showing the URL the helper would
+    have sent.
+
 .NOTES
     File:         Tests/Documenter/Invoke-SentinelRest.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -24,6 +36,7 @@
     Created:      2026-06-03
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-AnalyticalRuleYaml.Tests.ps1
+++ b/Tests/Test-AnalyticalRuleYaml.Tests.ps1
@@ -24,6 +24,23 @@
     Also performs cross-file checks: every analytical rule's `id:` GUID
     must be unique across the entire AnalyticalRules tree.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1
+
+    Validates every analytical rule and hunting query YAML in the repo.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1 -FullName '*Analytical rule schema*'
+
+    Runs only the analytical-rule schema assertions, skipping the
+    hunting-query and cross-file checks.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for pinpointing which field of which
+    rule failed.
+
 .NOTES
     File:         Tests/Test-AnalyticalRuleYaml.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -31,18 +48,10 @@
     Created:      2026-04-29
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 
-    Run a focused subset:
-        Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1 -FullName '*Analytical rule schema*'
-
-    Verbose:
-        Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1 -Output Detailed
-
-    Prerequisites:
-        - Pester 5+ (Install-Module Pester -Force -SkipPublisherCheck)
-        - powershell-yaml (auto-installed by the harness if missing)
+    powershell-yaml is auto-installed by the harness if missing. Install
+    Pester with: Install-Module Pester -Force -SkipPublisherCheck
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-AnalyticalRuleYaml.Tests.ps1
+++ b/Tests/Test-AnalyticalRuleYaml.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-AnalyticalRuleYaml.Tests.ps1
+++ b/Tests/Test-AnalyticalRuleYaml.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -51,7 +50,7 @@
     Created:      2026-04-29
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 
     powershell-yaml is auto-installed by the harness if missing. Install
     Pester with: Install-Module Pester -Force -SkipPublisherCheck

--- a/Tests/Test-AnalyticalRuleYaml.Tests.ps1
+++ b/Tests/Test-AnalyticalRuleYaml.Tests.ps1
@@ -45,6 +45,7 @@
     File:         Tests/Test-AnalyticalRuleYaml.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-04-29
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-AnalyticalRuleYaml.Tests.ps1
+++ b/Tests/Test-AnalyticalRuleYaml.Tests.ps1
@@ -25,6 +25,12 @@
     must be unique across the entire AnalyticalRules tree.
 
 .NOTES
+    File:         Tests/Test-AnalyticalRuleYaml.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-04-29
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-AnalyticalRuleYaml.Tests.ps1
 

--- a/Tests/Test-AutomationRuleJson.Tests.ps1
+++ b/Tests/Test-AutomationRuleJson.Tests.ps1
@@ -14,6 +14,17 @@
     Cross-file invariant: every rule's `automationRuleId` GUID must be
     unique across the tree (Sentinel uses it as the resource name).
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-AutomationRuleJson.Tests.ps1
+
+    Validates every automation-rule JSON in the repo.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-AutomationRuleJson.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for pinpointing which field of which
+    rule failed.
+
 .NOTES
     File:         Tests/Test-AutomationRuleJson.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -21,8 +32,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-AutomationRuleJson.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-AutomationRuleJson.Tests.ps1
+++ b/Tests/Test-AutomationRuleJson.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-AutomationRuleJson.Tests.ps1
+++ b/Tests/Test-AutomationRuleJson.Tests.ps1
@@ -15,6 +15,12 @@
     unique across the tree (Sentinel uses it as the resource name).
 
 .NOTES
+    File:         Tests/Test-AutomationRuleJson.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-AutomationRuleJson.Tests.ps1
 #>

--- a/Tests/Test-AutomationRuleJson.Tests.ps1
+++ b/Tests/Test-AutomationRuleJson.Tests.ps1
@@ -29,6 +29,7 @@
     File:         Tests/Test-AutomationRuleJson.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-CopilotCustomisations.Tests.ps1
+++ b/Tests/Test-CopilotCustomisations.Tests.ps1
@@ -26,6 +26,12 @@
     surface directly in the PR check UI.
 
 .NOTES
+    File:         Tests/Test-CopilotCustomisations.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run as part of the repo-wide Pester gate
     (Tools/Invoke-PRValidation.ps1) on every PR via the
     `validate` job in .github/workflows/pr-validation.yml.

--- a/Tests/Test-CopilotCustomisations.Tests.ps1
+++ b/Tests/Test-CopilotCustomisations.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-CopilotCustomisations.Tests.ps1
+++ b/Tests/Test-CopilotCustomisations.Tests.ps1
@@ -25,6 +25,17 @@
     Generates per-file It blocks via -ForEach so per-file failures
     surface directly in the PR check UI.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-CopilotCustomisations.Tests.ps1
+
+    Validates the whole Copilot customisation set.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-CopilotCustomisations.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which agent or
+    instruction file broke a convention.
+
 .NOTES
     File:         Tests/Test-CopilotCustomisations.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -32,9 +43,11 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run as part of the repo-wide Pester gate
-    (Tools/Invoke-PRValidation.ps1) on every PR via the
-    `validate` job in .github/workflows/pr-validation.yml.
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+
+    Also runs as part of the repo-wide Pester gate
+    (Tools/Invoke-PRValidation.ps1) on every PR, via the `validate` job
+    in .github/workflows/pr-validation.yml.
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-CopilotCustomisations.Tests.ps1
+++ b/Tests/Test-CopilotCustomisations.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -46,7 +45,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 
     Also runs as part of the repo-wide Pester gate
     (Tools/Invoke-PRValidation.ps1) on every PR, via the `validate` job

--- a/Tests/Test-CopilotCustomisations.Tests.ps1
+++ b/Tests/Test-CopilotCustomisations.Tests.ps1
@@ -40,6 +40,7 @@
     File:         Tests/Test-CopilotCustomisations.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DcrIngestion.Tests.ps1
+++ b/Tests/Test-DcrIngestion.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-DcrIngestion.Tests.ps1
+++ b/Tests/Test-DcrIngestion.Tests.ps1
@@ -19,6 +19,14 @@
     Deliberately not covered: the token network call, the streaming loop,
     and the role assignment. Those need a real service principal and a
     deployed DCR, so they are verified live, not here.
+
+.NOTES
+    File:         Tests/Test-DcrIngestion.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {
@@ -101,7 +109,8 @@ Describe 'Test-DcrIngestion: script-level contract' {
     }
 
     It 'has the correct repo-relative header path' {
-        $script:sourceText | Should -Match 'Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion\.ps1'
+        $script:sourceText | Should -Match 'File:\s+Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion\.ps1'
+        $script:sourceText | Should -Match 'Repository:\s+Sentinel-As-Code'
     }
 
     It 'resolves the -Follow workspace defensively, not by direct index' {

--- a/Tests/Test-DcrIngestion.Tests.ps1
+++ b/Tests/Test-DcrIngestion.Tests.ps1
@@ -35,6 +35,7 @@
     File:         Tests/Test-DcrIngestion.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DcrIngestion.Tests.ps1
+++ b/Tests/Test-DcrIngestion.Tests.ps1
@@ -20,6 +20,17 @@
     and the role assignment. Those need a real service principal and a
     deployed DCR, so they are verified live, not here.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DcrIngestion.Tests.ps1
+
+    Runs the helper unit tests. Needs no Azure auth.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DcrIngestion.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for diagnosing a stream-resolution
+    or record-shape failure.
+
 .NOTES
     File:         Tests/Test-DcrIngestion.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -27,6 +38,7 @@
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-DefenderDetectionYaml.Tests.ps1
+++ b/Tests/Test-DefenderDetectionYaml.Tests.ps1
@@ -16,6 +16,17 @@
     Cross-file invariant: every rule's `displayName` must be unique across
     the tree (Defender uses display name as the deduplication key on update).
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DefenderDetectionYaml.Tests.ps1
+
+    Validates every Defender custom-detection YAML in the repo.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DefenderDetectionYaml.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for pinpointing which field of which
+    detection failed.
+
 .NOTES
     File:         Tests/Test-DefenderDetectionYaml.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -23,15 +34,9 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-DefenderDetectionYaml.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 
-    Verbose:
-        Invoke-Pester -Path Tests/Test-DefenderDetectionYaml.Tests.ps1 -Output Detailed
-
-    Prerequisites:
-        - Pester 5+
-        - powershell-yaml (auto-installed by the harness if missing)
+    powershell-yaml is auto-installed by the harness if missing.
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-DefenderDetectionYaml.Tests.ps1
+++ b/Tests/Test-DefenderDetectionYaml.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -37,7 +36,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 
     powershell-yaml is auto-installed by the harness if missing.
 #>

--- a/Tests/Test-DefenderDetectionYaml.Tests.ps1
+++ b/Tests/Test-DefenderDetectionYaml.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-DefenderDetectionYaml.Tests.ps1
+++ b/Tests/Test-DefenderDetectionYaml.Tests.ps1
@@ -31,6 +31,7 @@
     File:         Tests/Test-DefenderDetectionYaml.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DefenderDetectionYaml.Tests.ps1
+++ b/Tests/Test-DefenderDetectionYaml.Tests.ps1
@@ -17,6 +17,12 @@
     the tree (Defender uses display name as the deduplication key on update).
 
 .NOTES
+    File:         Tests/Test-DefenderDetectionYaml.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-DefenderDetectionYaml.Tests.ps1
 

--- a/Tests/Test-DependencyManifest.Tests.ps1
+++ b/Tests/Test-DependencyManifest.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-DependencyManifest.Tests.ps1
+++ b/Tests/Test-DependencyManifest.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -51,7 +50,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 
     powershell-yaml is auto-installed by the harness if missing. Install
     Pester with: Install-Module Pester -Force -SkipPublisherCheck

--- a/Tests/Test-DependencyManifest.Tests.ps1
+++ b/Tests/Test-DependencyManifest.Tests.ps1
@@ -30,6 +30,17 @@
     Generates per-entry It blocks via -ForEach so per-file failures surface
     cleanly in the PR check UI.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1
+
+    Validates dependencies.json against the content tree.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which manifest entry
+    no longer resolves.
+
 .NOTES
     File:         Tests/Test-DependencyManifest.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -37,15 +48,10 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 
-    Verbose:
-        Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1 -Output Detailed
-
-    Prerequisites:
-        - Pester 5+ (Install-Module Pester -Force -SkipPublisherCheck)
-        - powershell-yaml (auto-installed by the harness if missing)
+    powershell-yaml is auto-installed by the harness if missing. Install
+    Pester with: Install-Module Pester -Force -SkipPublisherCheck
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-DependencyManifest.Tests.ps1
+++ b/Tests/Test-DependencyManifest.Tests.ps1
@@ -45,6 +45,7 @@
     File:         Tests/Test-DependencyManifest.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DependencyManifest.Tests.ps1
+++ b/Tests/Test-DependencyManifest.Tests.ps1
@@ -31,6 +31,12 @@
     cleanly in the PR check UI.
 
 .NOTES
+    File:         Tests/Test-DependencyManifest.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-DependencyManifest.Tests.ps1
 

--- a/Tests/Test-DeployCustomContent.Tests.ps1
+++ b/Tests/Test-DeployCustomContent.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-DeployCustomContent.Tests.ps1
+++ b/Tests/Test-DeployCustomContent.Tests.ps1
@@ -23,6 +23,18 @@
     Helper-driven: imports script functions via the AST extractor in
     Tests/_helpers/Import-ScriptFunctions.psm1.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeployCustomContent.Tests.ps1
+
+    Runs the deploy-time unit tests. Needs no Azure context; the script's
+    functions are lifted out by the AST extractor.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeployCustomContent.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for diagnosing a dependency-graph or
+    file-ordering failure.
+
 .NOTES
     File:         Tests/Test-DeployCustomContent.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -30,8 +42,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-DeployCustomContent.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-DeployCustomContent.Tests.ps1
+++ b/Tests/Test-DeployCustomContent.Tests.ps1
@@ -39,6 +39,7 @@
     File:         Tests/Test-DeployCustomContent.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DeployCustomContent.Tests.ps1
+++ b/Tests/Test-DeployCustomContent.Tests.ps1
@@ -24,6 +24,12 @@
     Tests/_helpers/Import-ScriptFunctions.psm1.
 
 .NOTES
+    File:         Tests/Test-DeployCustomContent.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-DeployCustomContent.Tests.ps1
 #>

--- a/Tests/Test-DeployDefenderDetections.Tests.ps1
+++ b/Tests/Test-DeployDefenderDetections.Tests.ps1
@@ -35,6 +35,7 @@
     File:         Tests/Test-DeployDefenderDetections.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DeployDefenderDetections.Tests.ps1
+++ b/Tests/Test-DeployDefenderDetections.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-DeployDefenderDetections.Tests.ps1
+++ b/Tests/Test-DeployDefenderDetections.Tests.ps1
@@ -20,6 +20,17 @@
       - mitreTechniques and impactedAssets are forced to arrays
       - lastModifiedDateTime forwards from queryCondition
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeployDefenderDetections.Tests.ps1
+
+    Runs the YAML-to-Graph body conversion tests.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeployDefenderDetections.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for diagnosing which converted field
+    came out in the wrong shape.
+
 .NOTES
     File:         Tests/Test-DeployDefenderDetections.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -27,6 +38,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-DeployDefenderDetections.Tests.ps1
+++ b/Tests/Test-DeployDefenderDetections.Tests.ps1
@@ -19,6 +19,14 @@
       - responseActions default to an empty array when the rule has none
       - mitreTechniques and impactedAssets are forced to arrays
       - lastModifiedDateTime forwards from queryCondition
+
+.NOTES
+    File:         Tests/Test-DeployDefenderDetections.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-DeploySentinelContentHub.Tests.ps1
+++ b/Tests/Test-DeploySentinelContentHub.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-DeploySentinelContentHub.Tests.ps1
+++ b/Tests/Test-DeploySentinelContentHub.Tests.ps1
@@ -13,6 +13,14 @@
       - Test-RuleIsCustomised (the customisation-protection comparator
         that decides whether to overwrite a deployed rule with its
         Content Hub template, used by -ProtectCustomisedRules)
+
+.NOTES
+    File:         Tests/Test-DeploySentinelContentHub.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-DeploySentinelContentHub.Tests.ps1
+++ b/Tests/Test-DeploySentinelContentHub.Tests.ps1
@@ -28,6 +28,7 @@
     File:         Tests/Test-DeploySentinelContentHub.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-DeploySentinelContentHub.Tests.ps1
+++ b/Tests/Test-DeploySentinelContentHub.Tests.ps1
@@ -14,6 +14,16 @@
         that decides whether to overwrite a deployed rule with its
         Content Hub template, used by -ProtectCustomisedRules)
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeploySentinelContentHub.Tests.ps1
+
+    Runs the SemVer and customisation-detector tests.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-DeploySentinelContentHub.Tests.ps1 -FullName '*Test-RuleIsCustomised*'
+
+    Runs only the customisation-protection comparator assertions.
+
 .NOTES
     File:         Tests/Test-DeploySentinelContentHub.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -21,6 +31,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+++ b/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+++ b/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
@@ -21,6 +21,17 @@
     Deploy-CustomWorkbooks function); a separate end-to-end test against a
     live workspace is out of scope here.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+
+    Runs the folder-naming and JSON-formatting tests. Needs no Azure
+    context; the Main block is never executed.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ExportSentinelWorkbooks.Tests.ps1 -FullName '*ConvertTo-FolderName*'
+
+    Runs only the PascalCase folder-name derivation assertions.
+
 .NOTES
     File:         Tests/Test-ExportSentinelWorkbooks.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -28,6 +39,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+++ b/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
@@ -36,6 +36,7 @@
     File:         Tests/Test-ExportSentinelWorkbooks.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+++ b/Tests/Test-ExportSentinelWorkbooks.Tests.ps1
@@ -20,6 +20,14 @@
     the rest of the script does is exercised at deploy-time (the matching
     Deploy-CustomWorkbooks function); a separate end-to-end test against a
     live workspace is out of scope here.
+
+.NOTES
+    File:         Tests/Test-ExportSentinelWorkbooks.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-ImportCommunityRules.Tests.ps1
+++ b/Tests/Test-ImportCommunityRules.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-ImportCommunityRules.Tests.ps1
+++ b/Tests/Test-ImportCommunityRules.Tests.ps1
@@ -20,6 +20,16 @@
     Builds on the AST extractor in
     Tests/_helpers/Import-ScriptFunctions.psm1.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ImportCommunityRules.Tests.ps1
+
+    Runs the normalisation-pipeline tests.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ImportCommunityRules.Tests.ps1 -FullName '*ConvertTo-Iso8601Duration*'
+
+    Runs only the duration-shorthand expansion assertions.
+
 .NOTES
     File:         Tests/Test-ImportCommunityRules.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -27,6 +37,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 #>
 
 BeforeAll {

--- a/Tests/Test-ImportCommunityRules.Tests.ps1
+++ b/Tests/Test-ImportCommunityRules.Tests.ps1
@@ -34,6 +34,7 @@
     File:         Tests/Test-ImportCommunityRules.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-ImportCommunityRules.Tests.ps1
+++ b/Tests/Test-ImportCommunityRules.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -40,7 +39,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 #>
 
 BeforeAll {

--- a/Tests/Test-ImportCommunityRules.Tests.ps1
+++ b/Tests/Test-ImportCommunityRules.Tests.ps1
@@ -19,6 +19,14 @@
 
     Builds on the AST extractor in
     Tests/_helpers/Import-ScriptFunctions.psm1.
+
+.NOTES
+    File:         Tests/Test-ImportCommunityRules.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-ImportScriptFunctions.Tests.ps1
+++ b/Tests/Test-ImportScriptFunctions.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-ImportScriptFunctions.Tests.ps1
+++ b/Tests/Test-ImportScriptFunctions.Tests.ps1
@@ -27,6 +27,7 @@
     File:         Tests/Test-ImportScriptFunctions.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-ImportScriptFunctions.Tests.ps1
+++ b/Tests/Test-ImportScriptFunctions.Tests.ps1
@@ -11,6 +11,14 @@
     written into $TestDrive, plus one real-repo round-trip against
     Tools/Test-SentinelRuleDrift.ps1 to confirm the helper works on
     the original reference suite's source.
+
+.NOTES
+    File:         Tests/Test-ImportScriptFunctions.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-ImportScriptFunctions.Tests.ps1
+++ b/Tests/Test-ImportScriptFunctions.Tests.ps1
@@ -12,6 +12,17 @@
     Tools/Test-SentinelRuleDrift.ps1 to confirm the helper works on
     the original reference suite's source.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ImportScriptFunctions.Tests.ps1
+
+    Runs the AST-extractor self-test. Run this first when several script
+    test suites fail at once, since the helper is their common dependency.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ImportScriptFunctions.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for diagnosing an extraction failure.
+
 .NOTES
     File:         Tests/Test-ImportScriptFunctions.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -19,6 +30,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-InvokeClassicTableMigration.Tests.ps1
+++ b/Tests/Test-InvokeClassicTableMigration.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-InvokeClassicTableMigration.Tests.ps1
+++ b/Tests/Test-InvokeClassicTableMigration.Tests.ps1
@@ -20,6 +20,16 @@
     migrated once, so they are not unit-testable. The script gates all
     three behind ShouldProcess for that reason.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-InvokeClassicTableMigration.Tests.ps1
+
+    Runs the column-mapping and ARM-shape tests. Needs no workspace.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-InvokeClassicTableMigration.Tests.ps1 -FullName '*ConvertTo-StreamColumn*'
+
+    Runs only the stream-declaration assertions.
+
 .NOTES
     File:         Tests/Test-InvokeClassicTableMigration.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -27,6 +37,7 @@
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-InvokeClassicTableMigration.Tests.ps1
+++ b/Tests/Test-InvokeClassicTableMigration.Tests.ps1
@@ -34,6 +34,7 @@
     File:         Tests/Test-InvokeClassicTableMigration.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-InvokeClassicTableMigration.Tests.ps1
+++ b/Tests/Test-InvokeClassicTableMigration.Tests.ps1
@@ -19,6 +19,14 @@
     deployment. Those need a live workspace and a table that can only be
     migrated once, so they are not unit-testable. The script gates all
     three behind ShouldProcess for that reason.
+
+.NOTES
+    File:         Tests/Test-InvokeClassicTableMigration.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {
@@ -156,7 +164,8 @@ Describe 'Invoke-ClassicTableMigration: script-level contract' {
     }
 
     It 'has the correct repo-relative header path' {
-        $script:sourceText | Should -Match 'Sentinel-As-Code/Tools/ClassicToDcr/Invoke-ClassicTableMigration\.ps1'
+        $script:sourceText | Should -Match 'File:\s+Tools/ClassicToDcr/Invoke-ClassicTableMigration\.ps1'
+        $script:sourceText | Should -Match 'Repository:\s+Sentinel-As-Code'
     }
 
     It 'is standalone: does not import the Sentinel.Common module' {

--- a/Tests/Test-InvokeTableMigrationReview.Tests.ps1
+++ b/Tests/Test-InvokeTableMigrationReview.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-InvokeTableMigrationReview.Tests.ps1
+++ b/Tests/Test-InvokeTableMigrationReview.Tests.ps1
@@ -29,6 +29,18 @@
     Deliberately not covered: the ARM calls, the Content Hub package fetch, and
     the HTML/CSV/JSON writers. Those need a live workspace.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-InvokeTableMigrationReview.Tests.ps1
+
+    Runs the impact-scoring and connector-classification tests, plus the
+    report.html.template contract checks.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-InvokeTableMigrationReview.Tests.ps1 -FullName '*Resolve-IndirectTableImpact*'
+
+    Runs only the parser-chain resolution assertions, the case where a
+    miss would break rules silently.
+
 .NOTES
     File:         Tests/Test-InvokeTableMigrationReview.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -36,6 +48,11 @@
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
+
+    One assertion couples the script's .NOTES Version to the version badge
+    in Tools/ClassicToDcr/Templates/report.html.template. Bump both
+    together or this suite fails.
 #>
 
 BeforeAll {

--- a/Tests/Test-InvokeTableMigrationReview.Tests.ps1
+++ b/Tests/Test-InvokeTableMigrationReview.Tests.ps1
@@ -28,6 +28,14 @@
 
     Deliberately not covered: the ARM calls, the Content Hub package fetch, and
     the HTML/CSV/JSON writers. Those need a live workspace.
+
+.NOTES
+    File:         Tests/Test-InvokeTableMigrationReview.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {
@@ -52,7 +60,8 @@ Describe 'Invoke-TableMigrationReview: script-level contract' {
     }
 
     It 'has the correct repo-relative header path' {
-        $script:sourceText | Should -Match 'Sentinel-As-Code/Tools/ClassicToDcr/Invoke-TableMigrationReview\.ps1'
+        $script:sourceText | Should -Match 'File:\s+Tools/ClassicToDcr/Invoke-TableMigrationReview\.ps1'
+        $script:sourceText | Should -Match 'Repository:\s+Sentinel-As-Code'
     }
 
     It 'records its origin as the folded-in CLv1 analyzer' {

--- a/Tests/Test-InvokeTableMigrationReview.Tests.ps1
+++ b/Tests/Test-InvokeTableMigrationReview.Tests.ps1
@@ -45,6 +45,7 @@
     File:         Tests/Test-InvokeTableMigrationReview.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-NewClassicTableFixture.Tests.ps1
+++ b/Tests/Test-NewClassicTableFixture.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-NewClassicTableFixture.Tests.ps1
+++ b/Tests/Test-NewClassicTableFixture.Tests.ps1
@@ -32,6 +32,7 @@
     File:         Tests/Test-NewClassicTableFixture.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-NewClassicTableFixture.Tests.ps1
+++ b/Tests/Test-NewClassicTableFixture.Tests.ps1
@@ -16,6 +16,14 @@
     Deliberately not covered: the live POST, the shared-key fetch, and the
     table poll. Those need a real workspace and the retiring Data Collector
     API, so they cannot be unit tested.
+
+.NOTES
+    File:         Tests/Test-NewClassicTableFixture.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {
@@ -85,7 +93,8 @@ Describe 'New-ClassicTableFixture: script-level contract' {
     }
 
     It 'has the correct repo-relative header path' {
-        $script:sourceText | Should -Match 'Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture\.ps1'
+        $script:sourceText | Should -Match 'File:\s+Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture\.ps1'
+        $script:sourceText | Should -Match 'Repository:\s+Sentinel-As-Code'
     }
 
     It 'is standalone: does not import the Sentinel.Common module' {

--- a/Tests/Test-NewClassicTableFixture.Tests.ps1
+++ b/Tests/Test-NewClassicTableFixture.Tests.ps1
@@ -17,6 +17,17 @@
     table poll. Those need a real workspace and the retiring Data Collector
     API, so they cannot be unit tested.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewClassicTableFixture.Tests.ps1
+
+    Runs the signature and record-shape tests. Needs no workspace.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewClassicTableFixture.Tests.ps1 -FullName '*New-DataCollectorSignature*'
+
+    Runs only the HMAC-SHA256 signature assertions, the failure that would
+    otherwise present as a silent 403.
+
 .NOTES
     File:         Tests/Test-NewClassicTableFixture.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -24,6 +35,7 @@
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-NewDcrFromSchema.Tests.ps1
+++ b/Tests/Test-NewDcrFromSchema.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-NewDcrFromSchema.Tests.ps1
+++ b/Tests/Test-NewDcrFromSchema.Tests.ps1
@@ -46,6 +46,7 @@
     File:         Tests/Test-NewDcrFromSchema.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-30
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-NewDcrFromSchema.Tests.ps1
+++ b/Tests/Test-NewDcrFromSchema.Tests.ps1
@@ -31,6 +31,17 @@
     assignment. Those need a live workspace, so the script gates them behind
     ShouldProcess and they are exercised by running the tool, not by Pester.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewDcrFromSchema.Tests.ps1
+
+    Runs the schema-validation and template-shape tests. Needs no workspace.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewDcrFromSchema.Tests.ps1 -FullName '*Get-DefaultTransform*'
+
+    Runs only the transform-cast assertions, the ones guarding against
+    InvalidTransformOutput at deploy time.
+
 .NOTES
     File:         Tests/Test-NewDcrFromSchema.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -38,6 +49,7 @@
     Created:      2026-07-30
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-NewDcrFromSchema.Tests.ps1
+++ b/Tests/Test-NewDcrFromSchema.Tests.ps1
@@ -30,6 +30,14 @@
     Deliberately not covered: the Azure reads, the deployments and the role
     assignment. Those need a live workspace, so the script gates them behind
     ShouldProcess and they are exercised by running the tool, not by Pester.
+
+.NOTES
+    File:         Tests/Test-NewDcrFromSchema.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-30
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-NewDependencyFixture.Tests.ps1
+++ b/Tests/Test-NewDependencyFixture.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-NewDependencyFixture.Tests.ps1
+++ b/Tests/Test-NewDependencyFixture.Tests.ps1
@@ -26,6 +26,14 @@
     Deliberately not covered: the live POST, the shared-key fetch, the ARM
     writes and the table polls. Those need a real workspace and the retiring
     Data Collector API, so they cannot be unit tested.
+
+.NOTES
+    File:         Tests/Test-NewDependencyFixture.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {
@@ -75,7 +83,8 @@ Describe 'New-DependencyFixture: script-level contract' {
     }
 
     It 'has the correct repo-relative header path' {
-        $script:sourceText | Should -Match 'Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture\.ps1'
+        $script:sourceText | Should -Match 'File:\s+Tools/ClassicToDcr/Rehearsal/New-DependencyFixture\.ps1'
+        $script:sourceText | Should -Match 'Repository:\s+Sentinel-As-Code'
     }
 
     It 'is standalone: does not import the Sentinel.Common module' {

--- a/Tests/Test-NewDependencyFixture.Tests.ps1
+++ b/Tests/Test-NewDependencyFixture.Tests.ps1
@@ -42,6 +42,7 @@
     File:         Tests/Test-NewDependencyFixture.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-NewDependencyFixture.Tests.ps1
+++ b/Tests/Test-NewDependencyFixture.Tests.ps1
@@ -27,6 +27,17 @@
     writes and the table polls. Those need a real workspace and the retiring
     Data Collector API, so they cannot be unit tested.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewDependencyFixture.Tests.ps1
+
+    Runs the naming-plan and ownership-gate tests. Needs no workspace.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-NewDependencyFixture.Tests.ps1 -FullName '*Test-FixtureOwned*'
+
+    Runs only the ownership gates that authorise a delete, the assertions
+    protecting real workspace content from the teardown path.
+
 .NOTES
     File:         Tests/Test-NewDependencyFixture.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -34,6 +45,7 @@
     Created:      2026-07-28
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-ParserYaml.Tests.ps1
+++ b/Tests/Test-ParserYaml.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-ParserYaml.Tests.ps1
+++ b/Tests/Test-ParserYaml.Tests.ps1
@@ -33,6 +33,7 @@
     File:         Tests/Test-ParserYaml.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-ParserYaml.Tests.ps1
+++ b/Tests/Test-ParserYaml.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -39,7 +38,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-ParserYaml.Tests.ps1
+++ b/Tests/Test-ParserYaml.Tests.ps1
@@ -18,6 +18,12 @@
       (Sentinel rejects duplicates)
 
 .NOTES
+    File:         Tests/Test-ParserYaml.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-ParserYaml.Tests.ps1
 #>

--- a/Tests/Test-ParserYaml.Tests.ps1
+++ b/Tests/Test-ParserYaml.Tests.ps1
@@ -17,6 +17,18 @@
     - functionAlias uniqueness: globally unique across the parser tree
       (Sentinel rejects duplicates)
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ParserYaml.Tests.ps1
+
+    Validates every parser YAML in the repo, including global
+    functionAlias uniqueness.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-ParserYaml.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which parser broke
+    the alias contract.
+
 .NOTES
     File:         Tests/Test-ParserYaml.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -24,8 +36,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-ParserYaml.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-PlaybookArm.Tests.ps1
+++ b/Tests/Test-PlaybookArm.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-PlaybookArm.Tests.ps1
+++ b/Tests/Test-PlaybookArm.Tests.ps1
@@ -26,6 +26,17 @@
     same defaultValue (e.g. RevokeSessions, VirusTotalIPReport), and the
     deploy logic is expected to distinguish them via tier/parent.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-PlaybookArm.Tests.ps1
+
+    Validates every playbook ARM template in the repo.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-PlaybookArm.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which playbook is
+    missing a trigger, action or parameter.
+
 .NOTES
     File:         Tests/Test-PlaybookArm.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -33,8 +44,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-PlaybookArm.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-PlaybookArm.Tests.ps1
+++ b/Tests/Test-PlaybookArm.Tests.ps1
@@ -41,6 +41,7 @@
     File:         Tests/Test-PlaybookArm.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-PlaybookArm.Tests.ps1
+++ b/Tests/Test-PlaybookArm.Tests.ps1
@@ -27,6 +27,12 @@
     deploy logic is expected to distinguish them via tier/parent.
 
 .NOTES
+    File:         Tests/Test-PlaybookArm.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-PlaybookArm.Tests.ps1
 #>

--- a/Tests/Test-PullRequestTemplate.Tests.ps1
+++ b/Tests/Test-PullRequestTemplate.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-PullRequestTemplate.Tests.ps1
+++ b/Tests/Test-PullRequestTemplate.Tests.ps1
@@ -16,6 +16,14 @@
     The harness AST-extracts those functions (via the shared
     Import-ScriptFunctions helper) and dot-sources them, so the script's
     entry-point (which calls exit) never runs.
+
+.NOTES
+    File:         Tests/Test-PullRequestTemplate.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-10
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-PullRequestTemplate.Tests.ps1
+++ b/Tests/Test-PullRequestTemplate.Tests.ps1
@@ -32,6 +32,7 @@
     File:         Tests/Test-PullRequestTemplate.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-10
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-PullRequestTemplate.Tests.ps1
+++ b/Tests/Test-PullRequestTemplate.Tests.ps1
@@ -17,6 +17,17 @@
     Import-ScriptFunctions helper) and dot-sources them, so the script's
     entry-point (which calls exit) never runs.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-PullRequestTemplate.Tests.ps1
+
+    Runs the PR-template parsing and validation tests. The script's
+    entry-point, which calls exit, never runs.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-PullRequestTemplate.Tests.ps1 -FullName '*Test-PullRequestTemplateBody*'
+
+    Runs only the body-validation assertions.
+
 .NOTES
     File:         Tests/Test-PullRequestTemplate.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -24,6 +35,7 @@
     Created:      2026-07-10
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-SentinelCommon.Tests.ps1
+++ b/Tests/Test-SentinelCommon.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
-#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules Az.Accounts
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }, Az.Accounts
 
 <#
 .SYNOPSIS

--- a/Tests/Test-SentinelCommon.Tests.ps1
+++ b/Tests/Test-SentinelCommon.Tests.ps1
@@ -17,6 +17,14 @@
     Uses Pester 5's Mock cmdlet to stub Az PowerShell calls so the
     suite runs offline with no Azure context. Each test imports the
     module fresh (Force) to avoid cross-test state leakage.
+
+.NOTES
+    File:         Tests/Test-SentinelCommon.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-SentinelCommon.Tests.ps1
+++ b/Tests/Test-SentinelCommon.Tests.ps1
@@ -34,6 +34,7 @@
     File:         Tests/Test-SentinelCommon.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-SentinelCommon.Tests.ps1
+++ b/Tests/Test-SentinelCommon.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS

--- a/Tests/Test-SentinelCommon.Tests.ps1
+++ b/Tests/Test-SentinelCommon.Tests.ps1
@@ -18,6 +18,18 @@
     suite runs offline with no Azure context. Each test imports the
     module fresh (Force) to avoid cross-test state leakage.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SentinelCommon.Tests.ps1
+
+    Runs the shared-module unit tests. Runs offline; the Az calls are
+    mocked.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SentinelCommon.Tests.ps1 -FullName '*Invoke-SentinelApi*'
+
+    Runs only the REST-wrapper assertions, including the
+    retry-on-transient-failure path.
+
 .NOTES
     File:         Tests/Test-SentinelCommon.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -25,6 +37,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+, Az.Accounts
 #>
 
 BeforeAll {

--- a/Tests/Test-SentinelRuleDrift.Tests.ps1
+++ b/Tests/Test-SentinelRuleDrift.Tests.ps1
@@ -1,4 +1,6 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tests/Test-SentinelRuleDrift.Tests.ps1
+++ b/Tests/Test-SentinelRuleDrift.Tests.ps1
@@ -22,6 +22,22 @@
     This lets us exercise pure functions without triggering the script's
     Invoke-Main entry-point (which would try to authenticate to Azure).
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1
+
+    Runs the full drift-comparison suite. The script's Invoke-Main
+    entry-point, which would authenticate to Azure, never runs.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1 -FullName '*Compare-SentinelRule*'
+
+    Runs only the rule-comparison Describe block.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for diagnosing a YAML-rewrite failure.
+
 .NOTES
     File:         Tests/Test-SentinelRuleDrift.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -29,18 +45,10 @@
     Created:      2026-04-28
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
 
-    Run a single Describe block:
-        Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1 -FullName '*Compare-SentinelRule*'
-
-    Verbose output:
-        Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1 -Output Detailed
-
-    Prerequisites:
-        - Pester 5+ (Install-Module Pester -Force -SkipPublisherCheck)
-        - powershell-yaml (auto-installed by the YAML-related tests if missing)
+    powershell-yaml is auto-installed by the YAML-related tests if missing.
+    Install Pester with: Install-Module Pester -Force -SkipPublisherCheck
 #>
 
 BeforeAll {

--- a/Tests/Test-SentinelRuleDrift.Tests.ps1
+++ b/Tests/Test-SentinelRuleDrift.Tests.ps1
@@ -42,6 +42,7 @@
     File:         Tests/Test-SentinelRuleDrift.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-04-28
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-SentinelRuleDrift.Tests.ps1
+++ b/Tests/Test-SentinelRuleDrift.Tests.ps1
@@ -23,6 +23,12 @@
     Invoke-Main entry-point (which would try to authenticate to Azure).
 
 .NOTES
+    File:         Tests/Test-SentinelRuleDrift.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-04-28
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-SentinelRuleDrift.Tests.ps1
 

--- a/Tests/Test-SentinelRuleDrift.Tests.ps1
+++ b/Tests/Test-SentinelRuleDrift.Tests.ps1
@@ -1,6 +1,5 @@
 #Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -48,7 +47,7 @@
     Created:      2026-04-28
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:     PowerShell 7.2+, Pester 5+, powershell-yaml (auto-installed if missing)
 
     powershell-yaml is auto-installed by the YAML-related tests if missing.
     Install Pester with: Install-Module Pester -Force -SkipPublisherCheck

--- a/Tests/Test-SetPlaybookPermissions.Tests.ps1
+++ b/Tests/Test-SetPlaybookPermissions.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-SetPlaybookPermissions.Tests.ps1
+++ b/Tests/Test-SetPlaybookPermissions.Tests.ps1
@@ -19,6 +19,17 @@
     pulls the function bodies but NOT those top-level table definitions,
     so the BeforeAll block sets them up to mirror the source script.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SetPlaybookPermissions.Tests.ps1
+
+    Runs the connector-to-role mapping and scope-resolution tests.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SetPlaybookPermissions.Tests.ps1 -FullName '*Get-PlaybookRequiredRoles*'
+
+    Runs only the role-extraction assertions, including the
+    Responder-to-Contributor upgrade rule.
+
 .NOTES
     File:         Tests/Test-SetPlaybookPermissions.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -26,6 +37,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeAll {

--- a/Tests/Test-SetPlaybookPermissions.Tests.ps1
+++ b/Tests/Test-SetPlaybookPermissions.Tests.ps1
@@ -34,6 +34,7 @@
     File:         Tests/Test-SetPlaybookPermissions.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-SetPlaybookPermissions.Tests.ps1
+++ b/Tests/Test-SetPlaybookPermissions.Tests.ps1
@@ -18,6 +18,14 @@
     $ContributorActionPatterns, $HttpMsiAudienceRoles. The AST extractor
     pulls the function bodies but NOT those top-level table definitions,
     so the BeforeAll block sets them up to mirror the source script.
+
+.NOTES
+    File:         Tests/Test-SetPlaybookPermissions.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 BeforeAll {

--- a/Tests/Test-SummaryRuleJson.Tests.ps1
+++ b/Tests/Test-SummaryRuleJson.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-SummaryRuleJson.Tests.ps1
+++ b/Tests/Test-SummaryRuleJson.Tests.ps1
@@ -32,6 +32,7 @@
     File:         Tests/Test-SummaryRuleJson.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-SummaryRuleJson.Tests.ps1
+++ b/Tests/Test-SummaryRuleJson.Tests.ps1
@@ -18,6 +18,12 @@
     (Sentinel uses `name` as the resource name in the PUT URL).
 
 .NOTES
+    File:         Tests/Test-SummaryRuleJson.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-SummaryRuleJson.Tests.ps1
 #>

--- a/Tests/Test-SummaryRuleJson.Tests.ps1
+++ b/Tests/Test-SummaryRuleJson.Tests.ps1
@@ -17,6 +17,17 @@
     Cross-file invariant: every rule's `name` is unique across the tree
     (Sentinel uses `name` as the resource name in the PUT URL).
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SummaryRuleJson.Tests.ps1
+
+    Validates every summary-rule JSON in the repo.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-SummaryRuleJson.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which KQL restriction
+    a rule violated.
+
 .NOTES
     File:         Tests/Test-SummaryRuleJson.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -24,8 +35,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-SummaryRuleJson.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-WatchlistJson.Tests.ps1
+++ b/Tests/Test-WatchlistJson.Tests.ps1
@@ -21,6 +21,18 @@
     Test cases generated per directory rather than per file so JSON-vs-CSV
     pairing checks live in the same test scope.
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-WatchlistJson.Tests.ps1
+
+    Validates every watchlist.json and its sibling data.csv, including the
+    itemsSearchKey-to-CSV-header invariant.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-WatchlistJson.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which watchlist
+    declares a search key its CSV does not carry.
+
 .NOTES
     File:         Tests/Test-WatchlistJson.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -28,14 +40,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-WatchlistJson.Tests.ps1
-
-    Verbose:
-        Invoke-Pester -Path Tests/Test-WatchlistJson.Tests.ps1 -Output Detailed
-
-    Prerequisites:
-        - Pester 5+
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-WatchlistJson.Tests.ps1
+++ b/Tests/Test-WatchlistJson.Tests.ps1
@@ -37,6 +37,7 @@
     File:         Tests/Test-WatchlistJson.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/Test-WatchlistJson.Tests.ps1
+++ b/Tests/Test-WatchlistJson.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-WatchlistJson.Tests.ps1
+++ b/Tests/Test-WatchlistJson.Tests.ps1
@@ -22,6 +22,12 @@
     pairing checks live in the same test scope.
 
 .NOTES
+    File:         Tests/Test-WatchlistJson.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-WatchlistJson.Tests.ps1
 

--- a/Tests/Test-WorkbookJson.Tests.ps1
+++ b/Tests/Test-WorkbookJson.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 
 <#

--- a/Tests/Test-WorkbookJson.Tests.ps1
+++ b/Tests/Test-WorkbookJson.Tests.ps1
@@ -29,6 +29,12 @@
     across the tree (Sentinel uses it as the workbook resource name).
 
 .NOTES
+    File:         Tests/Test-WorkbookJson.Tests.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Run all tests:
         Invoke-Pester -Path Tests/Test-WorkbookJson.Tests.ps1
 #>

--- a/Tests/Test-WorkbookJson.Tests.ps1
+++ b/Tests/Test-WorkbookJson.Tests.ps1
@@ -28,6 +28,18 @@
     Cross-file invariant: every ARM workbook resource GUID is unique
     across the tree (Sentinel uses it as the workbook resource name).
 
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-WorkbookJson.Tests.ps1
+
+    Validates every workbook.json in the repo, in either the ARM template
+    or gallery notebook format.
+
+.EXAMPLE
+    Invoke-Pester -Path Tests/Test-WorkbookJson.Tests.ps1 -Output Detailed
+
+    Runs with per-assertion output, for identifying which workbook failed
+    format detection.
+
 .NOTES
     File:         Tests/Test-WorkbookJson.Tests.ps1
     Repository:   Sentinel-As-Code
@@ -35,8 +47,7 @@
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Run all tests:
-        Invoke-Pester -Path Tests/Test-WorkbookJson.Tests.ps1
+    Requires:     PowerShell 7.2+, Pester 5+
 #>
 
 BeforeDiscovery {

--- a/Tests/Test-WorkbookJson.Tests.ps1
+++ b/Tests/Test-WorkbookJson.Tests.ps1
@@ -44,6 +44,7 @@
     File:         Tests/Test-WorkbookJson.Tests.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tests/_helpers/Import-ScriptFunctions.psm1
+++ b/Tests/_helpers/Import-ScriptFunctions.psm1
@@ -22,18 +22,18 @@
     test suite stops carrying its own copy.
 
 .NOTES
-    File:           Tests/_helpers/Import-ScriptFunctions.psm1
-    Created:        2026-04-29
+    File:         Tests/_helpers/Import-ScriptFunctions.psm1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-04-29
+    Version:      1.0.1
+    Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+
+
     Used by every Tests/Test-{Script}.Tests.ps1 file. A regression in
     Import-ScriptFunctions affects all of them at once, so the helper
     itself ships with its own self-test in
     Tests/Test-ImportScriptFunctions.Tests.ps1.
-
-    Author:         noodlemctwoodle
-    Version:        1.0.1
-    Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
-    Requires:       PowerShell 7.2+
 #>
 
 Set-StrictMode -Version Latest

--- a/Tests/_helpers/Import-ScriptFunctions.psm1
+++ b/Tests/_helpers/Import-ScriptFunctions.psm1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Test-suite helper that AST-extracts every top-level function from a

--- a/Tests/_helpers/Import-ScriptFunctions.psm1
+++ b/Tests/_helpers/Import-ScriptFunctions.psm1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tests/_helpers/Import-ScriptFunctions.psm1
-#
-# Created by noodlemctwoodle on 29/04/2026.
-#
-
 <#
 .SYNOPSIS
     Test-suite helper that AST-extracts every top-level function from a
@@ -28,14 +22,16 @@
     test suite stops carrying its own copy.
 
 .NOTES
+    File:           Tests/_helpers/Import-ScriptFunctions.psm1
+    Created:        2026-04-29
     Used by every Tests/Test-{Script}.Tests.ps1 file. A regression in
     Import-ScriptFunctions affects all of them at once, so the helper
     itself ships with its own self-test in
     Tests/Test-ImportScriptFunctions.Tests.ps1.
 
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-29
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+
 #>

--- a/Tests/_helpers/Import-ScriptFunctions.psm1
+++ b/Tests/_helpers/Import-ScriptFunctions.psm1
@@ -25,6 +25,7 @@
     File:         Tests/_helpers/Import-ScriptFunctions.psm1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-04-29
     Version:      1.0.1
     Last Updated: 2026-09-01

--- a/Tools/Build-DependencyManifest.ps1
+++ b/Tools/Build-DependencyManifest.ps1
@@ -72,9 +72,11 @@
     on match, 1 on drift (with the diff printed).
 
 .NOTES
+    File:           Tools/Build-DependencyManifest.ps1
+    Created:        2026-05-13
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-29
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, powershell-yaml, Sentinel.Common
 #>

--- a/Tools/Build-DependencyManifest.ps1
+++ b/Tools/Build-DependencyManifest.ps1
@@ -73,11 +73,11 @@
 
 .NOTES
     File:           Tools/Build-DependencyManifest.ps1
-    Created:        2026-05-13
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, powershell-yaml, Sentinel.Common
 #>
 

--- a/Tools/Build-DependencyManifest.ps1
+++ b/Tools/Build-DependencyManifest.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 7.2
+#Requires -Modules powershell-yaml
+
 <#
 .SYNOPSIS
     Discovers content dependencies from KQL queries embedded in

--- a/Tools/Build-DependencyManifest.ps1
+++ b/Tools/Build-DependencyManifest.ps1
@@ -75,6 +75,7 @@
     File:           Tools/Build-DependencyManifest.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Build-DependencyManifest.ps1
+++ b/Tools/Build-DependencyManifest.ps1
@@ -1,5 +1,4 @@
 #Requires -Version 7.2
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS
@@ -82,7 +81,7 @@
     Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       PowerShell 7.2+, powershell-yaml, Sentinel.Common
+    Requires:       PowerShell 7.2+, powershell-yaml (auto-installed if missing), Sentinel.Common
 #>
 
 [CmdletBinding()]

--- a/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
+++ b/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
-#
-# Created by noodlemctwoodle on 20/07/2026.
-#
-
 #Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources
 
@@ -198,9 +192,11 @@
     RawData into the table's columns before associating any machines.
 
 .NOTES
+    File:         Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
+    Created:      2026-07-20
     Author:       noodlemctwoodle
-    Version:      2.0.0
-    Last Updated: 2026-07-23
+    Version:      2.0.1
+    Last Updated: 2026-09-01
     Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources

--- a/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
+++ b/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
@@ -214,9 +214,12 @@
                                 'endpoints', so Direct DCRs authored here
                                 receive a built-in logsIngestion endpoint)
 
-    Reference:
-      https://learn.microsoft.com/powershell/module/az.operationalinsights/invoke-azoperationalinsightsmigratetable
-      https://learn.microsoft.com/azure/azure-monitor/logs/custom-logs-migrate
+
+.LINK
+    https://learn.microsoft.com/powershell/module/az.operationalinsights/invoke-azoperationalinsightsmigratetable
+
+.LINK
+    https://learn.microsoft.com/azure/azure-monitor/logs/custom-logs-migrate
 #>
 
 [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'ByName')]

--- a/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
+++ b/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
@@ -195,10 +195,10 @@
     File:         Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-20
     Version:      2.0.1
     Last Updated: 2026-09-01
-    Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 
     Runs standalone. Nothing from this repository needs to be alongside it.

--- a/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
+++ b/Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
@@ -193,11 +193,11 @@
 
 .NOTES
     File:         Tools/ClassicToDcr/Invoke-ClassicTableMigration.ps1
-    Created:      2026-07-20
+    Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Created:      2026-07-20
     Version:      2.0.1
     Last Updated: 2026-09-01
-    Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 

--- a/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
+++ b/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
@@ -63,10 +63,13 @@
     Scripted mode - outputs all reports to ./reports/2026-04.
 
 .NOTES
-    Version: 0.2.0
-
+    File:         Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
+    Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
                   https://github.com/noodlemctwoodle
+    Created:      2026-07-28
+    Version:      0.2.1
+    Last Updated: 2026-09-01
 
     Data source:
         Azure-Sentinel Solutions Analyzer

--- a/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
+++ b/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
@@ -58,6 +58,7 @@
     File:         Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      0.2.1
     Last Updated: 2026-09-01

--- a/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
+++ b/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 7.0
+#Requires -Version 7.2
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.13.0' }
 
 <#
@@ -62,7 +62,7 @@
     Created:      2026-07-28
     Version:      0.2.1
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.0+, Az.Accounts 2.13.0+
+    Requires:     PowerShell 7.2+, Az.Accounts 2.13.0+
 
     Provenance:
         Originated as the Sentinel-CLv1-Analyzer project (MIT, by

--- a/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
+++ b/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
@@ -1,11 +1,3 @@
-#
-# Sentinel-As-Code/Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
-#
-# Originated as the Sentinel-CLv1-Analyzer project (MIT, by noodlemctwoodle),
-# now folded into Sentinel-As-Code (Apache-2.0) as the assess-and-plan stage
-# of the ClassicToDcr migration toolkit.
-#
-
 #Requires -Version 7.0
 #Requires -Modules @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.13.0' }
 
@@ -66,14 +58,23 @@
     File:         Tools/ClassicToDcr/Invoke-TableMigrationReview.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
-                  https://github.com/noodlemctwoodle
     Created:      2026-07-28
     Version:      0.2.1
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.0+, Az.Accounts 2.13.0+
+
+    Provenance:
+        Originated as the Sentinel-CLv1-Analyzer project (MIT, by
+        noodlemctwoodle), now folded into Sentinel-As-Code (Apache-2.0)
+        as the assess-and-plan stage of the ClassicToDcr migration
+        toolkit.
 
     Data source:
         Azure-Sentinel Solutions Analyzer
         https://github.com/Azure/Azure-Sentinel/tree/master/Tools/Solutions%20Analyzer
+
+    Runs standalone. Nothing else from this repository needs to sit
+    alongside it.
 
 .LINK
     https://github.com/noodlemctwoodle/Sentinel-CLv1-Analyzer

--- a/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
@@ -116,11 +116,11 @@
 
 .NOTES
     File:         Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
-    Created:      2026-07-23
+    Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Created:      2026-07-23
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 

--- a/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
@@ -136,8 +136,9 @@
       - Log Analytics Contributor on the workspace (read shared keys,
         delete the table)
 
-    Reference:
-      https://learn.microsoft.com/azure/azure-monitor/logs/data-collector-api
+
+.LINK
+    https://learn.microsoft.com/azure/azure-monitor/logs/data-collector-api
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
-#
-# Created by noodlemctwoodle on 23/07/2026.
-#
-
 #Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights
 
@@ -121,9 +115,11 @@
     Deletes the fixture table.
 
 .NOTES
+    File:         Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+    Created:      2026-07-23
     Author:       noodlemctwoodle
-    Version:      1.0.0
-    Last Updated: 2026-07-23
+    Version:      1.0.1
+    Last Updated: 2026-09-01
     Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights

--- a/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
@@ -124,6 +124,12 @@
     Last Updated: 2026-09-01
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 
+    API versions:
+      - Log Analytics tables : 2023-09-01
+      - Data Collector API   : 2016-04-01 (the classic ingestion path this
+                               fixture deliberately exercises; it retires on
+                               2026-09-14)
+
     Runs standalone. Nothing from this repository needs to be alongside it.
 
     Required RBAC:

--- a/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
@@ -118,10 +118,10 @@
     File:         Tools/ClassicToDcr/Rehearsal/New-ClassicTableFixture.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-23
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 
     Runs standalone. Nothing from this repository needs to be alongside it.

--- a/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
-#
-# Created by noodlemctwoodle on 28/07/2026.
-#
-
 #Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights
 
@@ -186,9 +180,11 @@
     Tables API will accept the delete.
 
 .NOTES
+    File:         Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+    Created:      2026-07-28
     Author:       noodlemctwoodle
-    Version:      1.0.0
-    Last Updated: 2026-07-28
+    Version:      1.0.1
+    Last Updated: 2026-09-01
     Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights

--- a/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
@@ -229,10 +229,15 @@
       - The HTTP Data Collector API retires on 2026-09-14. After that date this
         script cannot create classic tables, because nothing can.
 
-    Reference:
-      https://learn.microsoft.com/azure/azure-monitor/logs/data-collector-api
-      https://learn.microsoft.com/azure/azure-monitor/logs/functions
-      https://learn.microsoft.com/rest/api/securityinsights/alert-rules/create-or-update
+
+.LINK
+    https://learn.microsoft.com/azure/azure-monitor/logs/data-collector-api
+
+.LINK
+    https://learn.microsoft.com/azure/azure-monitor/logs/functions
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules/create-or-update
 #>
 
 [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]

--- a/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
@@ -189,6 +189,13 @@
     Last Updated: 2026-09-01
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 
+    API versions:
+      - Log Analytics tables : 2023-09-01
+      - Saved searches       : 2020-08-01 (the parser functions the indirect
+                               dependency chains are built from)
+      - Sentinel alert rules : 2024-03-01
+      - Data Collector API   : 2016-04-01 (retires 2026-09-14)
+
     Runs standalone. Nothing from this repository needs to be alongside it. The
     bundled data/solution-mapping.json is used for the alias guard when it is
     present, and the script falls back to a static list with a warning when it

--- a/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
@@ -181,11 +181,11 @@
 
 .NOTES
     File:         Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
-    Created:      2026-07-28
+    Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Created:      2026-07-28
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 

--- a/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
@@ -183,10 +183,10 @@
     File:         Tools/ClassicToDcr/Rehearsal/New-DependencyFixture.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-28
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights
 
     Runs standalone. Nothing from this repository needs to be alongside it. The

--- a/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
@@ -84,6 +84,11 @@
     After each batch, query the destination table for rows from this run
     and report how many have arrived. Subject to ingestion latency.
 
+.PARAMETER ArrivalTimeoutSeconds
+    How long -Follow waits for rows to surface in the destination table
+    before giving up. Defaults to 300. Raise it on a workspace with slow
+    ingestion; a timeout is reported, not treated as data loss.
+
 .PARAMETER GrantIngestionRole
     Grant the service principal Monitoring Metrics Publisher on the DCR if
     it does not already have it. Off by default: the script otherwise
@@ -120,11 +125,11 @@
 
 .NOTES
     File:         Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
-    Created:      2026-07-23
+    Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Created:      2026-07-23
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 

--- a/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
@@ -149,8 +149,9 @@
     A freshly granted role can take a few minutes to take effect for
     data-plane calls, so expect 401/403 immediately after -GrantIngestionRole.
 
-    Reference:
-      https://learn.microsoft.com/azure/azure-monitor/logs/logs-ingestion-api-overview
+
+.LINK
+    https://learn.microsoft.com/azure/azure-monitor/logs/logs-ingestion-api-overview
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
@@ -127,10 +127,10 @@
     File:         Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-23
     Version:      1.0.1
     Last Updated: 2026-09-01
-    Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 
     Runs standalone. Nothing from this repository needs to be alongside it.

--- a/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
-#
-# Created by noodlemctwoodle on 23/07/2026.
-#
-
 #Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources
 
@@ -125,9 +119,11 @@
     Sends three batches of five records and stops.
 
 .NOTES
+    File:         Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+    Created:      2026-07-23
     Author:       noodlemctwoodle
-    Version:      1.0.0
-    Last Updated: 2026-07-23
+    Version:      1.0.1
+    Last Updated: 2026-09-01
     Repository:   Sentinel-As-Code
     Website:      https://sentinel.blog
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources

--- a/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
+++ b/Tools/ClassicToDcr/Rehearsal/Test-DcrIngestion.ps1
@@ -133,6 +133,11 @@
     Last Updated: 2026-09-01
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 
+    API versions:
+      - Data collection rules : 2023-03-11
+      - Logs Ingestion        : 2023-01-01 (the data-plane version used for
+                                the POST this script proves out)
+
     Runs standalone. Nothing from this repository needs to be alongside it.
 
     RBAC:

--- a/Tools/ClassicToDcr/Templates/report.html.template
+++ b/Tools/ClassicToDcr/Templates/report.html.template
@@ -939,7 +939,7 @@
         <div style="display:flex;gap:6px;align-items:center;flex-shrink:0;">
           <span class="version-badge">
             <svg class="icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-            v0.2.0 · PowerShell
+            v0.2.1 · PowerShell
           </span>
         </div>
       </div>

--- a/Tools/DcrFromSchema/New-DcrFromSchema.ps1
+++ b/Tools/DcrFromSchema/New-DcrFromSchema.ps1
@@ -254,6 +254,13 @@
     Last Updated: 2026-09-01
     Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
 
+    API versions:
+      - Log Analytics tables  : 2025-07-01
+      - Data collection rules : 2023-03-11 (the version that added
+                                'endpoints', so Direct DCRs authored here
+                                receive a built-in logsIngestion endpoint)
+      - Logs Ingestion        : 2023-01-01
+
     Run Connect-AzAccount before invoking.
 
     RBAC:

--- a/Tools/DcrFromSchema/New-DcrFromSchema.ps1
+++ b/Tools/DcrFromSchema/New-DcrFromSchema.ps1
@@ -248,11 +248,13 @@
     File:         Tools/DcrFromSchema/New-DcrFromSchema.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-07-30
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights,
-                  Az.Resources, and an active Connect-AzAccount session
+    Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights, Az.Resources
+
+    Run Connect-AzAccount before invoking.
 
     RBAC:
       - Log Analytics Contributor on the workspace, to create the table

--- a/Tools/DcrFromSchema/New-DcrFromSchema.ps1
+++ b/Tools/DcrFromSchema/New-DcrFromSchema.ps1
@@ -245,6 +245,12 @@
     paths and, when deployed, the immutable ID and ingestion endpoint.
 
 .NOTES
+    File:         Tools/DcrFromSchema/New-DcrFromSchema.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-07-30
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Sentinel-As-Code/Tools/DcrFromSchema/New-DcrFromSchema.ps1
 
     Created by noodlemctwoodle on 30/07/2026.

--- a/Tools/DcrFromSchema/New-DcrFromSchema.ps1
+++ b/Tools/DcrFromSchema/New-DcrFromSchema.ps1
@@ -251,14 +251,8 @@
     Created:      2026-07-30
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Sentinel-As-Code/Tools/DcrFromSchema/New-DcrFromSchema.ps1
-
-    Created by noodlemctwoodle on 30/07/2026.
-
-    Prerequisites:
-      - PowerShell 7.2+
-      - Az.Accounts, Az.OperationalInsights, Az.Resources
-      - Connect-AzAccount
+    Requires:     PowerShell 7.2+, Az.Accounts, Az.OperationalInsights,
+                  Az.Resources, and an active Connect-AzAccount session
 
     RBAC:
       - Log Analytics Contributor on the workspace, to create the table

--- a/Tools/Documenter/Convert-MermaidToImage.ps1
+++ b/Tools/Documenter/Convert-MermaidToImage.ps1
@@ -74,8 +74,11 @@
     Created:      2026-05-14
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Requires Node.js and @mermaid-js/mermaid-cli installed globally:
+    Requires:     PowerShell 7.2+, Node.js, @mermaid-js/mermaid-cli
+
+    Install the renderer globally with:
         npm install -g @mermaid-js/mermaid-cli
+
     On Linux CI agents the script writes a puppeteer config enabling
     --no-sandbox automatically.
 #>

--- a/Tools/Documenter/Convert-MermaidToImage.ps1
+++ b/Tools/Documenter/Convert-MermaidToImage.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Convert-MermaidToImage.ps1
-#
-# Created by noodlemctwoodle on 14/05/2026.
-#
-
 #requires -Version 7.2
 <#
 .SYNOPSIS
@@ -74,6 +68,12 @@
     pwsh ./Convert-MermaidToImage.ps1 -Root ./SecurityDocs -Format svg
 
 .NOTES
+    File:         Tools/Documenter/Convert-MermaidToImage.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-14
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Requires Node.js and @mermaid-js/mermaid-cli installed globally:
         npm install -g @mermaid-js/mermaid-cli
     On Linux CI agents the script writes a puppeteer config enabling

--- a/Tools/Documenter/Convert-MermaidToImage.ps1
+++ b/Tools/Documenter/Convert-MermaidToImage.ps1
@@ -1,4 +1,4 @@
-#requires -Version 7.2
+#Requires -Version 7.2
 
 <#
 .SYNOPSIS

--- a/Tools/Documenter/Convert-MermaidToImage.ps1
+++ b/Tools/Documenter/Convert-MermaidToImage.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.2
+
 <#
 .SYNOPSIS
     Pre-renders Mermaid fenced blocks in the Documenter's markdown output to

--- a/Tools/Documenter/Convert-MermaidToImage.ps1
+++ b/Tools/Documenter/Convert-MermaidToImage.ps1
@@ -71,6 +71,7 @@
     File:         Tools/Documenter/Convert-MermaidToImage.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-14
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
+++ b/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Render the JSON snapshot under SecurityDocs/<workspace>/_raw/ into the human-readable
@@ -50,9 +44,13 @@
     Tools/Documenter/Private/Resources.
 
 .NOTES
+    File:           Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
+    Repository:     Sentinel-As-Code
+    Created:        2026-05-06
+    Version:        0.1.0
     Author:         noodlemctwoodle
     Component:      Sentinel Documenter — Renderer
-    Last Updated:   2026-05-06
+    Last Updated:   2026-09-01
 #>
 
 [CmdletBinding()]

--- a/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
+++ b/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
@@ -43,14 +43,31 @@
     Folder containing best-practices.json, mitre-attack.json, etc. Defaults to
     Tools/Documenter/Private/Resources.
 
+.EXAMPLE
+    ./Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1 `
+        -WorkspaceName 'law-sentinel-prod'
+
+    Renders the Markdown section files from the inventory that
+    Export-SentinelInventory.ps1 previously collected.
+
+.EXAMPLE
+    ./Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1 `
+        -InputRoot     './SecurityDocs/law-sentinel-prod/_raw' `
+        -OutputRoot    './SecurityDocs/law-sentinel-prod' `
+        -WorkspaceName 'law-sentinel-prod'
+
+    Renders from an explicit collection folder, for regenerating the
+    document set from an archived inventory.
+
 .NOTES
     File:           Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
     Repository:     Sentinel-As-Code
+    Author:         noodlemctwoodle
     Created:        2026-05-06
     Version:        0.1.0
-    Author:         noodlemctwoodle
-    Component:      Sentinel Documenter — Renderer
     Last Updated:   2026-09-01
+    Component:      Sentinel Documenter, Renderer
+    Requires:       PowerShell 7.2+, powershell-yaml
 #>
 
 [CmdletBinding()]

--- a/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
+++ b/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
@@ -63,6 +63,7 @@
     File:           Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-06
     Version:        0.1.0
     Last Updated:   2026-09-01

--- a/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
+++ b/Tools/Documenter/Convert-SentinelInventoryToMarkdown.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 7.2
+#Requires -Modules powershell-yaml
+
 <#
 .SYNOPSIS
     Render the JSON snapshot under SecurityDocs/<workspace>/_raw/ into the human-readable

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources, Az.Monitor, Az.SecurityInsights, Az.LogicApp
 
 <#
@@ -70,7 +71,7 @@
     Version:        0.1.1
     Last Updated:   2026-09-01
     Component:      Sentinel Documenter
-    Requires:       Az.Accounts, Az.SecurityInsights, Az.OperationalInsights, Az.Monitor, Az.Resources, Az.LogicApp
+    Requires:       PowerShell 7.2+, Az.Accounts, Az.SecurityInsights, Az.OperationalInsights, Az.Monitor, Az.Resources, Az.LogicApp
 
     API versions:
       - Azure Resource Graph : 2022-10-01
@@ -108,8 +109,6 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$IncludePreview
 )
-
-#Requires -Modules Az.Accounts
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Export-SentinelInventory.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Export every Microsoft Sentinel artefact, the supporting Log Analytics + DCR layer,
@@ -45,10 +39,13 @@
     summary rules, pricings).
 
 .NOTES
+    File:           Tools/Documenter/Export-SentinelInventory.ps1
+    Repository:     Sentinel-As-Code
+    Created:        2026-05-06
     Author:         noodlemctwoodle
     Component:      Sentinel Documenter
-    Version:        0.1.0
-    Last Updated:   2026-05-06
+    Version:        0.1.1
+    Last Updated:   2026-09-01
     Requires:       Az.Accounts, Az.SecurityInsights, Az.OperationalInsights, Az.Monitor, Az.Resources, Az.LogicApp
 #>
 

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -38,6 +38,27 @@
     Use the 2024-10-01-preview API version where applicable (Content Hub product packages,
     summary rules, pricings).
 
+.PARAMETER PlaybookResourceGroup
+    Resource group holding the Logic App playbooks, when they do not live
+    alongside the workspace. Defaults to -ResourceGroup.
+
+.EXAMPLE
+    ./Tools/Documenter/Export-SentinelInventory.ps1 `
+        -ResourceGroup 'rg-sentinel-prod' `
+        -WorkspaceName 'law-sentinel-prod'
+
+    Exports the full inventory to ./SecurityDocs/law-sentinel-prod/_raw/.
+
+.EXAMPLE
+    ./Tools/Documenter/Export-SentinelInventory.ps1 `
+        -ResourceGroup 'rg-sentinel-prod' `
+        -WorkspaceName 'law-sentinel-prod' `
+        -PlaybookResourceGroup 'rg-soar-prod' `
+        -IncludePreview
+
+    Collects playbooks from a separate resource group and uses the preview
+    API version where one is available.
+
 .NOTES
     File:           Tools/Documenter/Export-SentinelInventory.ps1
     Repository:     Sentinel-As-Code

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, Az.OperationalInsights, Az.Resources, Az.Monitor, Az.SecurityInsights, Az.LogicApp
+
 <#
 .SYNOPSIS
     Export every Microsoft Sentinel artefact, the supporting Log Analytics + DCR layer,

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -69,6 +69,18 @@
     Last Updated:   2026-09-01
     Component:      Sentinel Documenter
     Requires:       Az.Accounts, Az.SecurityInsights, Az.OperationalInsights, Az.Monitor, Az.Resources, Az.LogicApp
+
+    API versions:
+      - Azure Resource Graph : 2022-10-01
+      - Everything else      : passed per collector through Invoke-SentinelRest,
+                               so a provider version can be bumped in one place
+                               without touching this script
+
+.LINK
+    https://learn.microsoft.com/azure/governance/resource-graph/first-query-rest-api
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
 #>
 
 [CmdletBinding()]

--- a/Tools/Documenter/Export-SentinelInventory.ps1
+++ b/Tools/Documenter/Export-SentinelInventory.ps1
@@ -62,11 +62,12 @@
 .NOTES
     File:           Tools/Documenter/Export-SentinelInventory.ps1
     Repository:     Sentinel-As-Code
-    Created:        2026-05-06
     Author:         noodlemctwoodle
-    Component:      Sentinel Documenter
+    Website:        https://sentinel.blog
+    Created:        2026-05-06
     Version:        0.1.1
     Last Updated:   2026-09-01
+    Component:      Sentinel Documenter
     Requires:       Az.Accounts, Az.SecurityInsights, Az.OperationalInsights, Az.Monitor, Az.Resources, Az.LogicApp
 #>
 

--- a/Tools/Documenter/Private/GapChecks.ps1
+++ b/Tools/Documenter/Private/GapChecks.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Gap-analysis check functions, one per row in best-practices.json.

--- a/Tools/Documenter/Private/GapChecks.ps1
+++ b/Tools/Documenter/Private/GapChecks.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/GapChecks.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Gap-analysis check functions, one per row in best-practices.json.
@@ -19,6 +13,11 @@
     row to best-practices.json that references it by name. The engine wires the rest.
 
 .NOTES
+    File:           Tools/Documenter/Private/GapChecks.ps1
+    Repository:     Sentinel-As-Code
+    Created:        2026-05-06
+    Version:        0.1.0
+    Last Updated:   2026-09-01
     Author:         noodlemctwoodle
     Component:      Sentinel Documenter, Gap Engine
 #>

--- a/Tools/Documenter/Private/GapChecks.ps1
+++ b/Tools/Documenter/Private/GapChecks.ps1
@@ -15,11 +15,14 @@
 .NOTES
     File:           Tools/Documenter/Private/GapChecks.ps1
     Repository:     Sentinel-As-Code
+    Author:         noodlemctwoodle
     Created:        2026-05-06
     Version:        0.1.0
     Last Updated:   2026-09-01
-    Author:         noodlemctwoodle
     Component:      Sentinel Documenter, Gap Engine
+
+    This file defines functions rather than running. Per-parameter detail
+    lives on each Test-* function's own help block.
 #>
 
 Set-StrictMode -Version Latest

--- a/Tools/Documenter/Private/GapChecks.ps1
+++ b/Tools/Documenter/Private/GapChecks.ps1
@@ -16,10 +16,12 @@
     File:           Tools/Documenter/Private/GapChecks.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-06
     Version:        0.1.0
     Last Updated:   2026-09-01
     Component:      Sentinel Documenter, Gap Engine
+    Requires:       PowerShell 7.2+
 
     This file defines functions rather than running. Per-parameter detail
     lives on each Test-* function's own help block.

--- a/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+++ b/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
@@ -31,6 +31,7 @@
     File:         Tools/Documenter/Private/Get-AzureRetailPrice.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-06
     Version:      0.1.0
     Last Updated: 2026-09-01

--- a/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+++ b/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
@@ -42,8 +42,8 @@
     Endpoint:
         https://prices.azure.com/api/retail/prices
 
-    Reference:
-        https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
+.LINK
+    https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
 #>
 
 function Get-AzureRetailPrice {

--- a/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+++ b/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Anonymous client for the Azure Retail Prices API with on-disk caching.

--- a/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+++ b/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Anonymous client for the Azure Retail Prices API with on-disk caching.
@@ -34,6 +28,12 @@
     holding the union of all returned price rows.
 
 .NOTES
+    File:         Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-06
+    Version:      0.1.0
+    Last Updated: 2026-09-01
     Endpoint: https://prices.azure.com/api/retail/prices
     Documentation: https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
 #>

--- a/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
+++ b/Tools/Documenter/Private/Get-AzureRetailPrice.ps1
@@ -34,8 +34,13 @@
     Created:      2026-05-06
     Version:      0.1.0
     Last Updated: 2026-09-01
-    Endpoint: https://prices.azure.com/api/retail/prices
-    Documentation: https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
+    Requires:     PowerShell 7.2+
+
+    Endpoint:
+        https://prices.azure.com/api/retail/prices
+
+    Reference:
+        https://learn.microsoft.com/rest/api/cost-management/retail-prices/azure-retail-prices
 #>
 
 function Get-AzureRetailPrice {

--- a/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
+++ b/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
-#
-# Created by noodlemctwoodle on 13/05/2026.
-#
-
 <#
 .SYNOPSIS
     Synthesise an "effective connectors" view from the captured inventory.
@@ -60,6 +54,14 @@
 
 .OUTPUTS
     [pscustomobject[]] with columns: Source, Identifier, Table, Last24hGB, LastIngested.
+
+.NOTES
+    File:         Tools/Documenter/Private/Get-EffectiveConnectors.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-13
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 function Get-EffectiveConnectors {
     [CmdletBinding()]

--- a/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
+++ b/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Synthesise an "effective connectors" view from the captured inventory.

--- a/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
+++ b/Tools/Documenter/Private/Get-EffectiveConnectors.ps1
@@ -59,9 +59,14 @@
     File:         Tools/Documenter/Private/Get-EffectiveConnectors.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-13
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+
+
+    This file defines functions rather than running. Per-parameter detail
+    lives on the function's own help block.
 #>
 function Get-EffectiveConnectors {
     [CmdletBinding()]

--- a/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
+++ b/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Compute an estimated monthly cost for the workspace from the captured 30-day Usage,
@@ -50,6 +44,14 @@
       - Data export egress.
       - Cross-region transfer.
       - Defender XDR-side meters.
+
+.NOTES
+    File:         Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-06
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 function Get-SentinelCostEstimate {

--- a/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
+++ b/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Compute an estimated monthly cost for the workspace from the captured 30-day Usage,

--- a/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
+++ b/Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
@@ -49,9 +49,14 @@
     File:         Tools/Documenter/Private/Get-SentinelCostEstimate.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-06
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+
+
+    This file defines functions rather than running. Per-parameter detail
+    lives on the function's own help block.
 #>
 
 function Get-SentinelCostEstimate {

--- a/Tools/Documenter/Private/Get-SentinelGap.ps1
+++ b/Tools/Documenter/Private/Get-SentinelGap.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/Get-SentinelGap.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Gap-analysis engine. Loads the best-practices ruleset, builds an in-memory
@@ -30,6 +24,14 @@
         Learn        : URL from best-practices.json
         CheckName    : Name of the Test-* function
         PassedAt     : ISO-8601 timestamp of the run
+
+.NOTES
+    File:         Tools/Documenter/Private/Get-SentinelGap.ps1
+    Repository:   Sentinel-As-Code
+    Author:       noodlemctwoodle
+    Created:      2026-05-06
+    Version:      0.1.0
+    Last Updated: 2026-09-01
 #>
 
 function Get-SentinelGap {

--- a/Tools/Documenter/Private/Get-SentinelGap.ps1
+++ b/Tools/Documenter/Private/Get-SentinelGap.ps1
@@ -29,9 +29,14 @@
     File:         Tools/Documenter/Private/Get-SentinelGap.ps1
     Repository:   Sentinel-As-Code
     Author:       noodlemctwoodle
+    Website:      https://sentinel.blog
     Created:      2026-05-06
     Version:      0.1.0
     Last Updated: 2026-09-01
+    Requires:     PowerShell 7.2+
+
+    This file defines functions rather than running. Per-parameter detail
+    lives on the function's own help block.
 #>
 
 function Get-SentinelGap {

--- a/Tools/Documenter/Private/Get-SentinelGap.ps1
+++ b/Tools/Documenter/Private/Get-SentinelGap.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Gap-analysis engine. Loads the best-practices ruleset, builds an in-memory

--- a/Tools/Documenter/Private/Invoke-SentinelRest.ps1
+++ b/Tools/Documenter/Private/Invoke-SentinelRest.ps1
@@ -45,11 +45,12 @@
 .NOTES
     File:           Tools/Documenter/Private/Invoke-SentinelRest.ps1
     Repository:     Sentinel-As-Code
+    Author:         noodlemctwoodle
     Created:        2026-05-06
     Version:        0.1.0
-    Author:         noodlemctwoodle
-    Component:      Sentinel Documenter
     Last Updated:   2026-09-01
+    Component:      Sentinel Documenter
+    Requires:       PowerShell 7.2+, Az.Accounts
 
     Multi-cloud:
       Invoke-AzRestMethod automatically routes ARM calls to the audience of the

--- a/Tools/Documenter/Private/Invoke-SentinelRest.ps1
+++ b/Tools/Documenter/Private/Invoke-SentinelRest.ps1
@@ -53,6 +53,10 @@
     Component:      Sentinel Documenter
     Requires:       PowerShell 7.2+, Az.Accounts
 
+    API versions:
+      - None pinned here. Each caller supplies its own via -ApiVersion, which
+        this helper appends to the request path.
+
     Multi-cloud:
       Invoke-AzRestMethod automatically routes ARM calls to the audience of the
       active Az context. To target a sovereign cloud, connect once before

--- a/Tools/Documenter/Private/Invoke-SentinelRest.ps1
+++ b/Tools/Documenter/Private/Invoke-SentinelRest.ps1
@@ -46,6 +46,7 @@
     File:           Tools/Documenter/Private/Invoke-SentinelRest.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-06
     Version:        0.1.0
     Last Updated:   2026-09-01

--- a/Tools/Documenter/Private/Invoke-SentinelRest.ps1
+++ b/Tools/Documenter/Private/Invoke-SentinelRest.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts
+
 <#
 .SYNOPSIS
     Paginating wrapper around Invoke-AzRestMethod for Sentinel and Azure Resource Manager

--- a/Tools/Documenter/Private/Invoke-SentinelRest.ps1
+++ b/Tools/Documenter/Private/Invoke-SentinelRest.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Private/Invoke-SentinelRest.ps1
-#
-# Created by noodlemctwoodle on 06/05/2026.
-#
-
 <#
 .SYNOPSIS
     Paginating wrapper around Invoke-AzRestMethod for Sentinel and Azure Resource Manager
@@ -49,9 +43,13 @@
     Invoke-SentinelRest -Path '/subscriptions/.../providers/Microsoft.SecurityInsights/dataConnectorDefinitions' -ApiVersion '2024-09-01'
 
 .NOTES
+    File:           Tools/Documenter/Private/Invoke-SentinelRest.ps1
+    Repository:     Sentinel-As-Code
+    Created:        2026-05-06
+    Version:        0.1.0
     Author:         noodlemctwoodle
     Component:      Sentinel Documenter
-    Last Updated:   2026-05-13
+    Last Updated:   2026-09-01
 
     Multi-cloud:
       Invoke-AzRestMethod automatically routes ARM calls to the audience of the

--- a/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
+++ b/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
@@ -85,11 +85,11 @@
 
 .NOTES
     File:           Tools/Documenter/Report/Convert-FolderToWordReport.ps1
-    Created:        2026-06-25
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-06-25
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, pandoc on PATH
 
     This is a generic folder-to-Word converter. It has no Sentinel or

--- a/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
+++ b/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
@@ -87,6 +87,7 @@
     File:           Tools/Documenter/Report/Convert-FolderToWordReport.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-06-25
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
+++ b/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
-#
-# Created by noodlemctwoodle on 25/06/2026.
-#
-
 <#
 .SYNOPSIS
     Render every file in a folder tree into a single, formatted Word
@@ -90,9 +84,11 @@
     Applies a branded reference template and a tighter per-file ceiling.
 
 .NOTES
+    File:           Tools/Documenter/Report/Convert-FolderToWordReport.ps1
+    Created:        2026-06-25
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-06-25
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, pandoc on PATH
 

--- a/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
+++ b/Tools/Documenter/Report/Convert-FolderToWordReport.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Render every file in a folder tree into a single, formatted Word

--- a/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
+++ b/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
@@ -114,11 +114,11 @@
 
 .NOTES
     File:           Tools/Documenter/Report/Convert-MarkdownToWord.ps1
-    Created:        2026-06-25
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-06-25
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, pandoc on PATH
 #>
 

--- a/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
+++ b/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
@@ -116,6 +116,7 @@
     File:           Tools/Documenter/Report/Convert-MarkdownToWord.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-06-25
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
+++ b/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     Combine a folder of Markdown files into a single, formatted Word

--- a/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
+++ b/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Documenter/Report/Convert-MarkdownToWord.ps1
-#
-# Created by noodlemctwoodle on 25/06/2026.
-#
-
 <#
 .SYNOPSIS
     Combine a folder of Markdown files into a single, formatted Word
@@ -119,9 +113,11 @@
         -Title      'SEC-UKS-PROD-SIEM-WS - Sentinel Documentation'
 
 .NOTES
+    File:           Tools/Documenter/Report/Convert-MarkdownToWord.ps1
+    Created:        2026-06-25
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-06-25
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, pandoc on PATH
 #>

--- a/Tools/Export-SentinelWorkbooks.ps1
+++ b/Tools/Export-SentinelWorkbooks.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 7.2
+#Requires -Modules Az.Accounts
+
 <#
 .SYNOPSIS
     Exports Microsoft Sentinel workbooks from a workspace to disk in the

--- a/Tools/Export-SentinelWorkbooks.ps1
+++ b/Tools/Export-SentinelWorkbooks.ps1
@@ -111,9 +111,11 @@
     Reports what would change without writing.
 
 .NOTES
+    File:           Tools/Export-SentinelWorkbooks.ps1
+    Created:        2026-05-13
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-30
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Az.Accounts, Sentinel.Common module
 

--- a/Tools/Export-SentinelWorkbooks.ps1
+++ b/Tools/Export-SentinelWorkbooks.ps1
@@ -114,6 +114,7 @@
     File:           Tools/Export-SentinelWorkbooks.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Export-SentinelWorkbooks.ps1
+++ b/Tools/Export-SentinelWorkbooks.ps1
@@ -112,11 +112,11 @@
 
 .NOTES
     File:           Tools/Export-SentinelWorkbooks.ps1
-    Created:        2026-05-13
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-05-13
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Az.Accounts, Sentinel.Common module
 
     Symmetry contract:

--- a/Tools/Export-SentinelWorkbooks.ps1
+++ b/Tools/Export-SentinelWorkbooks.ps1
@@ -120,6 +120,12 @@
     Last Updated:   2026-09-01
     Requires:       PowerShell 7.2+, Az.Accounts, Sentinel.Common module
 
+    API versions:
+      - Workbooks         : 2022-04-01 (matched to the deploy script, so an
+                            export/redeploy round-trip stays symmetrical)
+      - Sentinel metadata : 2025-09-01 (read to identify Content Hub-owned
+                            workbooks so they can be skipped)
+
     Symmetry contract:
 
       - Same JSON file shape as Deploy-CustomWorkbooks reads

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules powershell-yaml
 
 <#
@@ -83,7 +84,7 @@
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Requires:       powershell-yaml (auto-installed if missing); git 2.x or later in PATH
+    Requires:       PowerShell 7.2+, powershell-yaml (auto-installed if missing); git 2.x or later in PATH
 #>
 
 [CmdletBinding(SupportsShouldProcess)]

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -77,6 +77,7 @@
     File:           Tools/Import-CommunityRules.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -1,5 +1,4 @@
 #Requires -Version 7.2
-#Requires -Modules powershell-yaml
 
 <#
 .SYNOPSIS

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -75,11 +75,11 @@
 
 .NOTES
     File:           Tools/Import-CommunityRules.ps1
-    Created:        2026-04-28
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       powershell-yaml (auto-installed if missing); git 2.x or later in PATH
 #>
 

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -74,9 +74,11 @@
     sandbox folder).
 
 .NOTES
+    File:           Tools/Import-CommunityRules.ps1
+    Created:        2026-04-28
     Author:         noodlemctwoodle
-    Version:        1.1.0
-    Last Updated:   2026-04-28
+    Version:        1.1.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       powershell-yaml (auto-installed if missing); git 2.x or later in PATH
 #>

--- a/Tools/Import-CommunityRules.ps1
+++ b/Tools/Import-CommunityRules.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules powershell-yaml
+
 <#
 .SYNOPSIS
     Imports Microsoft Sentinel analytical rules from the David Alonso (Dalonso)

--- a/Tools/Invoke-DCRWatchlistSync.ps1
+++ b/Tools/Invoke-DCRWatchlistSync.ps1
@@ -56,12 +56,13 @@
 
 .NOTES
     File:           Tools/Invoke-DCRWatchlistSync.ps1
-    Created:        2026-03-23
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
+    Created:        2026-03-23
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
-    Website:        https://sentinel.blog
+    Requires:       PowerShell 7.2+, Az.Accounts
 
     Required RBAC on managed identity:
       - Monitoring Reader on subscription (to list DCRs and associations via ARM)

--- a/Tools/Invoke-DCRWatchlistSync.ps1
+++ b/Tools/Invoke-DCRWatchlistSync.ps1
@@ -37,9 +37,11 @@
     holds one aggregated row per DCR, so DCRName is the unique key).
 
 .NOTES
+    File:           Tools/Invoke-DCRWatchlistSync.ps1
+    Created:        2026-03-23
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-03-23
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Website:        https://sentinel.blog
 

--- a/Tools/Invoke-DCRWatchlistSync.ps1
+++ b/Tools/Invoke-DCRWatchlistSync.ps1
@@ -36,6 +36,24 @@
     Column used as the watchlist search key. Defaults to DCRName (the watchlist
     holds one aggregated row per DCR, so DCRName is the unique key).
 
+.EXAMPLE
+    ./Tools/Invoke-DCRWatchlistSync.ps1 `
+        -WorkspaceResourceGroup 'rg-sentinel-prod' `
+        -WorkspaceName          'law-sentinel-prod'
+
+    Enumerates every DCR and association visible to the identity, then
+    writes the aggregated inventory to the default watchlist alias.
+
+.EXAMPLE
+    ./Tools/Invoke-DCRWatchlistSync.ps1 `
+        -WorkspaceResourceGroup 'rg-sentinel-prod' `
+        -WorkspaceName          'law-sentinel-prod' `
+        -WatchlistAlias         'DcrInventoryTest' `
+        -WatchlistDisplayName   'DCR Inventory (test)'
+
+    Writes to a separate alias, for validating a schema change without
+    disturbing the watchlist that rules already query.
+
 .NOTES
     File:           Tools/Invoke-DCRWatchlistSync.ps1
     Created:        2026-03-23

--- a/Tools/Invoke-DCRWatchlistSync.ps1
+++ b/Tools/Invoke-DCRWatchlistSync.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts
 
 <#

--- a/Tools/Invoke-DCRWatchlistSync.ps1
+++ b/Tools/Invoke-DCRWatchlistSync.ps1
@@ -69,8 +69,14 @@
       - Microsoft Sentinel Contributor on Sentinel resource group (watchlist write)
 
     API versions:
-      - DCR / associations : 2024-03-11
-      - Sentinel watchlist : 2025-09-01
+      - DCRs and associations : 2024-03-11
+      - Sentinel watchlists   : 2025-09-01
+
+.LINK
+    https://learn.microsoft.com/rest/api/monitor/data-collection-rules
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/watchlists
 #>
 
 [CmdletBinding()]

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -64,11 +64,11 @@
 
 .NOTES
     File:           Tools/Invoke-PRValidation.ps1
-    Created:        2026-04-29
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-04-29
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       Pester 5+, powershell-yaml
 #>
 

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Pester, powershell-yaml
 
 <#
@@ -72,7 +73,7 @@
     Created:        2026-04-29
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       Pester 5+, powershell-yaml
+    Requires:       PowerShell 7.2+, Pester 5+, powershell-yaml
 #>
 
 [CmdletBinding()]

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Pester, powershell-yaml
+
 <#
 .SYNOPSIS
     PR-validation entry-point. Runs every Pester suite under Tests/ against the

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -66,6 +66,7 @@
     File:           Tools/Invoke-PRValidation.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-04-29
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -1,5 +1,4 @@
 #Requires -Version 7.2
-#Requires -Modules Pester, powershell-yaml
 
 <#
 .SYNOPSIS
@@ -73,7 +72,7 @@
     Created:        2026-04-29
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Requires:       PowerShell 7.2+, Pester 5+, powershell-yaml
+    Requires:       PowerShell 7.2+, Pester 5+ and powershell-yaml (both auto-installed if missing)
 #>
 
 [CmdletBinding()]

--- a/Tools/Invoke-PRValidation.ps1
+++ b/Tools/Invoke-PRValidation.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Invoke-PRValidation.ps1
-#
-# Created by noodlemctwoodle on 29/04/2026.
-#
-
 <#
 .SYNOPSIS
     PR-validation entry-point. Runs every Pester suite under Tests/ against the
@@ -69,9 +63,11 @@
     file locally.
 
 .NOTES
+    File:           Tools/Invoke-PRValidation.ps1
+    Created:        2026-04-29
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-04-29
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       Pester 5+, powershell-yaml
 #>

--- a/Tools/Migrate-ForkLayout.ps1
+++ b/Tools/Migrate-ForkLayout.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.2
+
 <#
 .SYNOPSIS
     One-shot helper for fork maintainers: relocates files left at the pre-26.06

--- a/Tools/Migrate-ForkLayout.ps1
+++ b/Tools/Migrate-ForkLayout.ps1
@@ -42,11 +42,11 @@
 
 .NOTES
     File:           Tools/Migrate-ForkLayout.ps1
+    Repository:     Sentinel-As-Code
+    Author:         noodlemctwoodle
     Created:        2026-06-03
     Version:        0.1.0
     Last Updated:   2026-09-01
-    Author:         noodlemctwoodle
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, git
 #>
 

--- a/Tools/Migrate-ForkLayout.ps1
+++ b/Tools/Migrate-ForkLayout.ps1
@@ -44,6 +44,7 @@
     File:           Tools/Migrate-ForkLayout.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-06-03
     Version:        0.1.0
     Last Updated:   2026-09-01

--- a/Tools/Migrate-ForkLayout.ps1
+++ b/Tools/Migrate-ForkLayout.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Migrate-ForkLayout.ps1
-#
-# Created by noodlemctwoodle on 03/06/2026.
-#
-
 <#
 .SYNOPSIS
     One-shot helper for fork maintainers: relocates files left at the pre-26.06
@@ -47,6 +41,10 @@
     Apply the moves.
 
 .NOTES
+    File:           Tools/Migrate-ForkLayout.ps1
+    Created:        2026-06-03
+    Version:        0.1.0
+    Last Updated:   2026-09-01
     Author:         noodlemctwoodle
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, git

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -1,9 +1,3 @@
-#
-# Sentinel-As-Code/Tools/Test-PullRequestTemplate.ps1
-#
-# Created by noodlemctwoodle on 08/07/2026.
-#
-
 #Requires -Version 7.2
 
 <#
@@ -66,9 +60,11 @@
     Validates a description read from a file. Handy for local testing.
 
 .NOTES
+    File:           Tools/Test-PullRequestTemplate.ps1
+    Created:        2026-07-08
     Author:         noodlemctwoodle
-    Version:        1.0.0
-    Last Updated:   2026-07-08
+    Version:        1.0.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Sentinel.Common (logging only)
 #>

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -61,11 +61,11 @@
 
 .NOTES
     File:           Tools/Test-PullRequestTemplate.ps1
-    Created:        2026-07-08
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-07-08
     Version:        1.0.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     Requires:       PowerShell 7.2+, Sentinel.Common (logging only)
 #>
 

--- a/Tools/Test-PullRequestTemplate.ps1
+++ b/Tools/Test-PullRequestTemplate.ps1
@@ -63,6 +63,7 @@
     File:           Tools/Test-PullRequestTemplate.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-07-08
     Version:        1.0.1
     Last Updated:   2026-09-01

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.2
 #Requires -Modules Az.Accounts, powershell-yaml
 
 <#
@@ -136,7 +137,7 @@
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Requires:       Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
 
     API versions:
       - Sentinel : 2025-09-01 (GA)
@@ -190,8 +191,6 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$WhatIf
 )
-
-#Requires -Modules Az.Accounts
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -128,11 +128,11 @@
 
 .NOTES
     File:           Tools/Test-SentinelRuleDrift.ps1
-    Created:        2026-04-28
+    Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Repository:     Sentinel-As-Code
     API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts, powershell-yaml
 #>

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -130,6 +130,7 @@
     File:           Tools/Test-SentinelRuleDrift.ps1
     Repository:     Sentinel-As-Code
     Author:         noodlemctwoodle
+    Website:        https://sentinel.blog
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Az.Accounts, powershell-yaml
+
 <#
 .SYNOPSIS
     Detects drift between Microsoft Sentinel Analytics Rules deployed in a workspace and

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -134,8 +134,13 @@
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts, powershell-yaml
+
+    API versions:
+      - Sentinel : 2025-09-01 (GA)
+
+.LINK
+    https://learn.microsoft.com/rest/api/securityinsights/alert-rules
 #>
 
 [CmdletBinding()]

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -127,9 +127,11 @@
     inspection before letting the pipeline auto-sync.
 
 .NOTES
+    File:           Tools/Test-SentinelRuleDrift.ps1
+    Created:        2026-04-28
     Author:         noodlemctwoodle
-    Version:        1.1.0
-    Last Updated:   2026-04-29
+    Version:        1.1.1
+    Last Updated:   2026-09-01
     Repository:     Sentinel-As-Code
     API Version:    2025-09-01 (GA)
     Requires:       Az.Accounts, powershell-yaml

--- a/Tools/Test-SentinelRuleDrift.ps1
+++ b/Tools/Test-SentinelRuleDrift.ps1
@@ -1,5 +1,5 @@
 #Requires -Version 7.2
-#Requires -Modules Az.Accounts, powershell-yaml
+#Requires -Modules Az.Accounts
 
 <#
 .SYNOPSIS
@@ -137,7 +137,7 @@
     Created:        2026-04-28
     Version:        1.1.1
     Last Updated:   2026-09-01
-    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml
+    Requires:       PowerShell 7.2+, Az.Accounts, powershell-yaml (auto-installed if missing)
 
     API versions:
       - Sentinel : 2025-09-01 (GA)


### PR DESCRIPTION
## Summary

Supersedes #57, which GitHub auto-closed when `main`'s history was rewritten
and its recorded head commit stopped resolving against the new base. Same
branch, same commits, same change; only the PR object is new. The review
discussion on #57 remains readable there.

Consolidates PowerShell file metadata into the comment-based help block and
gives every `.ps1` / `.psm1` in the repo the same header shape: `#Requires`
statements, then a `<# ... #>` block whose `.NOTES` records path, repository,
author, website, dates, version and dependencies. The five-line `#` path/date
banner is gone.

## Type of change

- [ ] New detection content (analytical rule / hunting query / Defender detection)
- [ ] Content update (rule tuning, query change, metadata fix)
- [ ] Infrastructure change (Bicep, deployment scripts)
- [ ] Pipeline / workflow change
- [ ] Documentation
- [ ] Bug fix
- [x] Other: repo-wide convention change plus the docs that define it

## Why is this change needed?

The repo had two competing homes for script metadata. A `#` banner above the
help block recorded the repo-relative path and a creation date, while `.NOTES`
inside the help block recorded author, version, last updated and repository.

Only 21 of 64 scripts carried the banner, so the path and creation date were
missing from the other 43, and no file recorded its path inside `.NOTES` at all.
One of the banners was also wrong, declaring
`Sentinel-As-Code/Workbooks/SentinelDataLake/...` and dropping the `Content/`
segment.

Two sources of truth for the same facts is one too many, and the comment-based
help block is the one `Get-Help` can actually read.

Auditing for that turned up a second problem worth fixing in the same pass:
scripts declared their dependencies in prose but not in `#Requires`, so a
missing module failed somewhere in the middle of a deployment rather than at
the door.

## What does this change do?

### Header shape

Every `.ps1` and `.psm1` opens with its `#Requires` statements, then the help
block, and nothing else above either.

```powershell
#Requires -Version 7.2
#Requires -Modules Az.Accounts, Az.OperationalInsights

<#
.SYNOPSIS
    ...
```

`.NOTES` carries the same eight keys everywhere, in a fixed order with values
aligned to one column: `File`, `Repository`, `Author`, `Website`, `Created`,
`Version`, `Last Updated`, `Requires`. Optional extras (`Component:`,
`Permissions:`) sit between `Last Updated:` and `Requires:`, so `Requires:` is
always last. `File` is the repo-relative path with no leading `./` and no
`Sentinel-As-Code/` prefix, since `Repository` already records that. Dates are
ISO `YYYY-MM-DD`; the banner's `DD/MM/YYYY` dates were converted, not discarded.

Files that call an Azure or Graph API also record the versions they pin, in a
labelled block after the keys, and carry a `.LINK` to the relevant Microsoft
Learn REST reference.

### #Requires and the `Requires:` key

`#Requires` is the functional gate; `Requires:` is the human-readable summary.
Neither may name something the other omits, with three deliberate exceptions
that would break the file if gated: `Sentinel.Common`, which is imported by
path rather than installed; CLI tooling such as `az` and `git`, which are not
PowerShell modules; and any module the file installs itself, since `#Requires`
aborts the load before the install could run. Those appear in `Requires:` only,
the self-installing ones marked `(auto-installed if missing)`.

`#Requires -Version 7.2` is mandatory in every file, matching the floor
declared in `Sentinel.Common.psd1`.

### Files

- **64 `.ps1` / `.psm1` files.** 21 banners removed, 20 `.NOTES` blocks added,
  keys normalised and aligned throughout, `#Requires` prologues added.
  Creation dates come from the banner where one existed and from the file's
  first commit otherwise. Versions bumped a patch level; files with no prior
  version start at `0.1.0`.
- **`.github/instructions/powershell-scripts.instructions.md`** and
  **`.github/copilot-instructions.md`.** Both documented the banner as
  required. Both now describe the `#Requires`-then-help-block shape, the eight
  `.NOTES` keys and the three `#Requires -Modules` carve-outs.
- **`Docs/Deploy/Scripts.md`** gains a "Script header convention" section so
  the rule is discoverable from the docs tree, not only from the Copilot
  instructions.
- **`Docs/Tests/Pester-Tests.md`** updated for the test-file header shape.
- **Five `Tests/*.Tests.ps1`.** The "has the correct repo-relative header path"
  assertions matched the banner string. They now assert the `.NOTES` `File:`
  and `Repository:` lines, preserving the original intent.
- **`Tools/ClassicToDcr/Templates/report.html.template`.** Version badge moved
  to `v0.2.1` in step with `Invoke-TableMigrationReview.ps1`, which
  `Test-InvokeTableMigrationReview.Tests.ps1` asserts must match.
- **`Docs/Releases/CHANGELOG.md`** and **`Docs/Releases/Versioning.md`.** The
  changelog stopped at `26.07.3`, published on 30 July, with six PRs merged
  since and unrecorded. A `26.09` section now covers those plus this one, and
  the wave-to-CalVer table gains the matching row. The README carries no
  version string or badge, so nothing there needed bumping.

The two `.psd1` manifests are untouched. They are data files with no
comment-based help, they already carry `Author` and `CompanyName`, and
`Sentinel.Common.psd1`'s `ModuleVersion` is read at import time.

`Sentinel.Common.psm1`'s `.NOTES Version:` was stale at `1.0.0` against a
manifest reading `1.1.1`, and is now realigned. `ModuleVersion` itself is
deliberately unchanged: the only edit to the module here is its comment header.

## Testing

- **Token-stream comparison** across all 64 changed scripts for the header
  consolidation. Each file was parsed before and after with the PowerShell AST
  parser, `Comment` and `NewLine` tokens stripped, and the remaining executable
  tokens compared. Zero differences, so that part of the change is provably
  comment-only.
- **Header audit** across all 64 files: every one leads with
  `#Requires -Version 7.2`, carries the eight `.NOTES` keys in order, and has a
  `Requires:` value that starts with the PowerShell floor.
- **Conflict sweep** for modules named in `#Requires -Modules` that the same
  file installs at runtime. Zero remaining.
- `Get-Help` resolves synopsis and notes on a sample script, confirming the
  help blocks are still well-formed.
- `Import-Module Sentinel.Common` exports its 9 commands.
- `./Tools/Invoke-PRValidation.ps1 -RepoPath .` passes: **7264 passed,
  0 failed**, matching the baseline on `main`.
