### PR TITLE
feat(ci): close nightly failure issues when the stage recovers

### DIFF
--- a/.github/workflows/sentinel-deploy-nightly.yml
+++ b/.github/workflows/sentinel-deploy-nightly.yml
@@ -42,6 +42,12 @@
 #   the workflow before the issue is closed updates the existing issue
 #   rather than spamming new ones.
 #
+#   When a stage goes green again, report-recovery closes that stage's
+#   issue and comments with the passing run. Recovery is tracked per
+#   stage, so one stage can recover in the same run where another
+#   fails. Without this an already-fixed failure stays open forever and
+#   the nightly-failure label stops meaning "currently broken".
+#
 # Concurrency:
 #   cancel-in-progress: false so multiple consecutive failures each
 #   keep their own context — useful for diagnosing intermittent vs
@@ -371,3 +377,93 @@ jobs:
           fi
 
           rm -f "$ISSUE_BODY_FILE"
+
+  # ===========================================================================
+  # Stage 7: Recovery reporting
+  # ===========================================================================
+  # The mirror of report-failure. When a stage that previously failed goes
+  # green again, close its tracking issue.
+  #
+  # Without this there is no recovery path at all: report-failure opens and
+  # refreshes an issue on every failure, but nothing ever closes one. A fixed
+  # failure therefore stays open indefinitely and the nightly-failure label
+  # stops meaning "currently broken". Issue #28 sat open for 16 days after the
+  # restructure in #27 had already fixed it, which is exactly the confusion
+  # this job removes.
+  #
+  # Runs on always() because recovery is per-stage: one stage can go green in
+  # the same run where another fails. This job closes the recovered stage's
+  # issue while report-failure opens or refreshes the still-broken one.
+  report-recovery:
+    name: "Close recovered failure issues"
+    runs-on: ubuntu-latest
+    needs: [check-infrastructure, deploy-infrastructure, deploy-content-hub, deploy-custom-content, deploy-defender-detections]
+    if: always()
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Close issues for stages that are now green
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Space-separated 'stage:result' entries. Deliberately a plain list
+          # rather than an associative array: 'declare -A' needs bash 4, which
+          # the runner has but a local shell may not, and this form stays
+          # testable anywhere. Neither stage names nor result values contain
+          # spaces or colons, so the splitting below is safe.
+          STAGES=""
+          STAGES="$STAGES check-infrastructure:${{ needs.check-infrastructure.result }}"
+          STAGES="$STAGES deploy-infrastructure:${{ needs.deploy-infrastructure.result }}"
+          STAGES="$STAGES deploy-content-hub:${{ needs.deploy-content-hub.result }}"
+          STAGES="$STAGES deploy-custom-content:${{ needs.deploy-custom-content.result }}"
+          STAGES="$STAGES deploy-defender-detections:${{ needs.deploy-defender-detections.result }}"
+
+          # Unquoted on purpose: word splitting is how the list is iterated.
+          for ENTRY in $STAGES; do
+              STAGE="${ENTRY%%:*}"
+              RESULT="${ENTRY##*:}"
+
+              # Only 'success' counts as recovery. A skipped stage is not
+              # evidence that anything was fixed (deploy-infrastructure skips
+              # routinely), so it leaves any open issue alone.
+              if [ "$RESULT" != "success" ]; then
+                  echo "$STAGE: $RESULT (no action)"
+                  continue
+              fi
+
+              TITLE="Nightly E2E deploy validation failed: $STAGE"
+
+              # Exact title match against label-filtered issues, rather than
+              # the fuzzy 'in:title' search the failure path uses. Closing the
+              # wrong issue is far worse than opening a duplicate, so this must
+              # not match a human-filed issue with a similar title.
+              NUM=$(gh issue list \
+                      --state open \
+                      --label nightly-failure \
+                      --limit 100 \
+                      --json number,title \
+                  | jq -r --arg t "$TITLE" '[.[] | select(.title == $t) | .number] | first // empty')
+
+              if [ -z "$NUM" ]; then
+                  echo "$STAGE: green, no open issue to close"
+                  continue
+              fi
+
+              echo "$STAGE: green, closing issue #$NUM"
+
+              # printf rather than a literal multi-line string: an unindented
+              # continuation line would dedent out of this 'run: |' block and
+              # break the workflow YAML. Single-quoted format so the backticks
+              # stay literal instead of becoming command substitution.
+              BODY=$(printf 'Recovered: `%s` passed in %s\n\nClosing automatically. If this stage breaks again the nightly will open a fresh issue rather than reopening this one.' \
+                     "$STAGE" "$RUN_URL")
+
+              gh issue comment "$NUM" --body "$BODY"
+              gh issue close "$NUM" --reason completed
+          done

--- a/Docs/Pipelines/Deploy-Nightly.md
+++ b/Docs/Pipelines/Deploy-Nightly.md
@@ -107,6 +107,9 @@ deploy-custom-content       Deploy-CustomContent.ps1 -WhatIf (no mutation).
 deploy-defender-detections  Deploy-DefenderDetections.ps1 -WhatIf.
         ▼
 report-failure              Runs only if any prior job failed.
+        ▼
+report-recovery             Always runs. Closes the tracking issue for
+                            any stage that is green again.
 ```
 
 Every deploy job first checks out the repo (`actions/checkout@v5`) and
@@ -241,6 +244,35 @@ that:
 
 De-duplicating on title means repeated failures at the same stage refresh
 one issue instead of spamming new ones.
+
+### 7. `report-recovery`
+
+`needs:` the same five deploy jobs, but conditional `always()`, because
+recovery is tracked per stage: one stage can go green in the same run
+where another fails. It declares its own job-level
+`permissions: { issues: write, contents: read }`.
+
+The bash step walks each stage's result and, for every stage that is
+`success`, looks for an open issue titled
+`Nightly E2E deploy validation failed: <stage>`. If it finds one it
+comments with a link to the passing run and closes it.
+
+Two deliberate restrictions:
+
+- Only `success` counts as recovery. A `skipped` stage is not evidence
+  that anything was fixed (`deploy-infrastructure` skips on every run
+  where the workspace already exists), so it leaves any open issue
+  alone.
+- The lookup filters on the `nightly-failure` label and matches the
+  title exactly, rather than using the fuzzy `in:title` search the
+  failure path uses. Closing the wrong issue is worse than opening a
+  duplicate, so it must not match a human-filed issue with a similar
+  title.
+
+Without this job there is no recovery path at all: `report-failure`
+opens and refreshes issues but nothing ever closes one, so a fixed
+failure stays open indefinitely and the `nightly-failure` label stops
+meaning "currently broken".
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

Adds a `report-recovery` job to the nightly E2E validation workflow that closes a stage's tracking issue when that stage goes green again. Documents it in `Docs/Pipelines/Deploy-Nightly.md`.

## Why is this change needed?

The nightly workflow had no recovery path. `report-failure` opens and refreshes an issue on every stage failure, but nothing ever closed one. A failure that had already been fixed stayed open indefinitely, and the `nightly-failure` label stopped meaning "currently broken".

Issue #28 is the worked example. `deploy-defender-detections` failed every night from 4 June because the workflow passed `-SubscriptionId` to `Deploy-DefenderDetections.ps1`, which accepts only `BasePath`, `IsGov` and `WhatIf`:

```
Deploy-DefenderDetections.ps1: A parameter cannot be found that matches parameter name 'SubscriptionId'.
```

The restructure in #27 (a7b2ab2, 7 July 09:50 BST) rewrote that invocation to `-BasePath` + `-WhatIf`. The timing is exact: the 7 July nightly ran at 04:22 and failed, the 8 July ran at 04:03 and passed. The stage has been green every night since, including today. But #28 was still open 16 days later carrying 33 "Re-failed" comments and no signal that it was fixed, which is precisely the confusion this job removes.

Worth noting the underlying deploy bug is already fixed and needs nothing here. Verified that today's run genuinely executed the Defender job rather than skipping it, and that the production deploy at `sentinel-deploy.yml` splats only `BasePath` and optional `WhatIf`, so Monday's deploy carries no latent version of it.

## What does this change do?

Adds `report-recovery`: `needs` the same five deploy jobs, conditional `always()`, with its own `permissions: { issues: write, contents: read }`. For each stage whose result is `success` it finds the matching open issue, comments with a link to the passing run, and closes it.

`always()` rather than a success condition because recovery is per stage: one stage can go green in the same run where another fails, and both the close and the open should happen.

Two deliberate restrictions:

- **Only `success` counts as recovery.** A `skipped` stage is not evidence that anything was fixed (`deploy-infrastructure` skips on every run where the workspace already exists), so it leaves any open issue alone.
- **Exact title match on label-filtered issues**, rather than reusing the fuzzy `in:title` search from the failure path. Closing the wrong issue is worse than opening a duplicate, so it must not match a human-filed issue with a similar title.

## What does this fix or affect?

Refs #28. Deliberately does not close it by hand: leaving it open means the first run after merge closes it automatically, which proves the job works end to end against the real case.

No behavioural change to any existing job. `report-recovery` only ever closes issues carrying the `nightly-failure` label whose title matches a stage name exactly.

## Type of change

- [x] feat - new capability
- [ ] fix - bug fix
- [ ] refactor - restructure without behavioural change
- [ ] perf - measurable performance improvement
- [ ] docs - documentation only
- [ ] test - Pester / schema test changes
- [ ] chore - dependency bump, version pin, file rename
- [x] ci - workflow / pipeline change
- [ ] tune - analytical-rule threshold / severity / filter change

## Files changed (high level)

- `.github/workflows/sentinel-deploy-nightly.yml` - new `report-recovery` job; header comment updated to describe the recovery path
- `Docs/Pipelines/Deploy-Nightly.md` - job added to the stage diagram, plus a section covering both restrictions

## Pre-merge checklist

- [ ] **Pester suite** passes locally (`./Tools/Invoke-PRValidation.ps1 -RepoPath .`)
- [ ] **Bicep build** passes locally if Bicep changed (`az bicep build --file Infra/sentinel/main.bicep --stdout > /dev/null`)
- [ ] **`dependencies.json` regenerated** if KQL content changed (`./Tools/Build-DependencyManifest.ps1 -Mode Generate`)
- [x] **Cross-platform parity** maintained if pipelines/workflows changed (ADO + GitHub both updated)
- [x] **Path-scoped instructions** still match the touched content type's schema
- [x] **No secrets** in committed files (env vars, hardcoded tokens, connection strings)
- [x] **Commit messages** follow conventional-commit format (type(scope): subject + detailed body)
- [x] **Documentation** updated if the change affects user-visible behaviour

Parity is ticked as not applicable: `Pipelines/` has no nightly equivalent, so this is GitHub-only. Bicep, `dependencies.json` and Pester are unticked because no Bicep, KQL or test files are touched; the CI gate runs them regardless.

## Testing

- Extracted the job's script exactly as the YAML parses it, substituted the `needs.*.result` expressions, and ran it against a stubbed `gh`. The fixture contained both issue #28 and a decoy whose title shares its full prefix (`... deploy-defender-detections (my notes)`). It closed 28, left the decoy alone, and rendered the comment correctly with the backticks literal and the blank line preserved.
- Exercised three run shapes: all-green-with-routine-skip, mixed (one stage recovered while another still fails), and all-red. Correct behaviour in each, exiting 0.
- An earlier version used an associative array; local testing showed `declare -A` needs bash 4. The runner has bash 5 so it would have worked, but the plain-list form has no version dependency and stays testable anywhere, so it was rewritten.
- Workflow confirmed to parse as valid YAML, with `report-recovery` present and its `if` / `needs` / `permissions` as intended.

Not smoke tested against a live run, since the job only fires on the schedule from the default branch. The first nightly after merge is the real test, and #28 is the case it should close.

## Related

- Refs #28
- Root cause fixed by #27


---

Supersedes #41, which GitHub auto-closed when `main`'s history was rewritten and refused to reopen. Same branch, same change, rebased onto the new base.
